### PR TITLE
Support for HTTP DELETE requests with a body

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -285,7 +285,7 @@ public class BrowserMobHttpClient {
     public BrowserMobHttpRequest newDelete(String url, net.lightbody.bmp.proxy.jetty.http.HttpRequest proxyRequest) {
         try {
             URI uri = makeUri(url);
-            return new BrowserMobHttpRequest(new HttpDelete(uri), this, -1, captureContent, proxyRequest);
+            return new BrowserMobHttpRequest(new HttpDeleteWithBody(uri), this, -1, captureContent, proxyRequest);
         } catch (URISyntaxException e) {
             throw reportBadURI(url, "DELETE");
         }

--- a/src/main/java/net/lightbody/bmp/proxy/http/HttpDeleteWithBody.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/HttpDeleteWithBody.java
@@ -1,0 +1,37 @@
+package net.lightbody.bmp.proxy.http;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import java.net.URI;
+import org.apache.http.annotation.NotThreadSafe;
+
+// Allows for HTTP DELETE requests to contain a body, which the HttpDelete
+// class does not support. Please see:
+//   http://stackoverflow.com/a/3820549/581722
+@NotThreadSafe
+public class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+
+    public final static String METHOD_NAME = "DELETE";
+
+    public HttpDeleteWithBody() {
+        super();
+    }
+
+    public HttpDeleteWithBody(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    /**
+     * @throws IllegalArgumentException if the uri is invalid.
+     */
+    public HttpDeleteWithBody(final String uri) {
+        super();
+        setURI(URI.create(uri));
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+
+}


### PR DESCRIPTION
The `HttpDelete` class used by BrowserMob Proxy does not support HTTP DELETE requests with a body. This pull request adds support for them.

There appears to be [some disagreement](http://stackoverflow.com/a/299696) whether this type of request is valid according to the [W3C specification](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html). That said, applications in the wild do it, browsers support it (or at least don't prohibit it), so it probably makes sense that BrowserMob Proxy supports it, too.

The new `HttpDeleteWithBody` class is based on [`HttpPost`](http://www.docjar.com/html/api/org/apache/http/client/methods/HttpPost.java.html). The source of this idea is this [Stack Overflow question](http://stackoverflow.com/a/3820549/581722).
