### PR TITLE
fix for slf4j compatibility issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,15 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.5.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.5.3</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I encountered slf4j compatibility issue when used browsermob-proxy in my current project. I think slf4j dependency should done as two dependencies: 
1. slf4j-api
2. slf4j-jdk14 with test scope.
