### PR TITLE
Allow binding of ProxyServer to an alternative host address

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -112,6 +112,9 @@ public class ProxyServer {
     }
 
     public void setLocalHost(InetAddress localHost) {
+        if (!localHost.isAnyLocalAddress()) {
+            throw new IllegalArgumentException("Must be address of a local adapter");
+        }
         this.localHost = localHost;
     }
 


### PR DESCRIPTION
This is to allow an alternative network interface to be used for the proxy, such as VPN interface. Although the ProxyServer allows connection through all interfaces, the address used in the proxy string passed to Selenium is not correct.

```
proxyServer = new ProxyServer(proxyPort);

// Specify connection via Juniper VPN interface
NetworkInterface vpn = NetworkInterface.getByName("jnc0");
proxyServer.setLocalHost(vpn.getInetAddresses().nextElement());

proxyServer.start();
```
