### PR TITLE
Please see Issue 19

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -864,19 +864,22 @@ public class BrowserMobHttpClient {
         //TODO - is there a better way of doing this?
         if (os != null && os instanceof ClonedOutputStream && captureContent ) {
             try {
-                if ( !gzipping && (contentType.startsWith("text/")  ||
-                        contentType.startsWith("application/x-javascript")) ||
-                        contentType.startsWith("application/javascript")  ||
-                        contentType.startsWith("application/json")  ||
-                        contentType.startsWith("application/xml")  ||
-                        contentType.startsWith("application/xhtml+xml")) {
+                if ( !gzipping &&
+                        ( contentType != null && (contentType.startsWith("text/")  ||
+                                contentType.startsWith("application/x-javascript") ||
+                                contentType.startsWith("application/javascript")  ||
+                                contentType.startsWith("application/json")  ||
+                                contentType.startsWith("application/xml")  ||
+                                contentType.startsWith("application/xhtml+xml") ) )
+                        )
+                {
                     ((ClonedOutputStream)os).writeAndCloseAll(output.getEntry().getResponse().getContent().getText());
                 }
                 else {
                     ((ClonedOutputStream)os).writeAndCloseAll( ) ;
                 }
             } catch (IOException e) {
-                e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+                e.printStackTrace();
             }
         }
 

--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -391,9 +391,6 @@ public class BrowserMobHttpClient {
             }
 
             BrowserMobHttpResponse response = execute(req, 1);
-            for (ResponseInterceptor interceptor : responseInterceptors) {
-                interceptor.process(response);
-            }
 
             return response;
         } finally {
@@ -498,6 +495,7 @@ public class BrowserMobHttpClient {
         long bytes = 0;
         boolean gzipping = false;
         boolean contentMatched = true;
+        // AF - do i want to do this here?
         OutputStream os = req.getOutputStream();
         if (os == null) {
             os = new CappedByteArrayOutputStream(1024 * 1024); // MOB-216 don't buffer more than 1 MB
@@ -505,7 +503,6 @@ public class BrowserMobHttpClient {
         if (verificationText != null) {
             contentMatched = false;
         }
-        Date start = new Date();
 
         // link the object up now, before we make the request, so that if we get cut off (ie: favicon.ico request and browser shuts down)
         // we still have the attempt associated, even if we never got a response
@@ -550,6 +547,7 @@ public class BrowserMobHttpClient {
         }
 
         StatusLine statusLine = null;
+        // where the work starts
         try {
             // set the User-Agent if it's not already set
             if (method.getHeaders("User-Agent").length == 0) {
@@ -596,6 +594,7 @@ public class BrowserMobHttpClient {
 				// No mechanism to look up the response text by status code, 
 				// so include a notification that this is a synthetic error code.
             } else {
+                //Happy path
                 response = httpClient.execute(method, ctx);
                 statusLine = response.getStatusLine();
                 statusCode = statusLine.getStatusCode();
@@ -622,9 +621,8 @@ public class BrowserMobHttpClient {
                     }
 
                     if (captureContent) {
-                        // todo - something here?
+//                        // todo - something here?
                         os = new ClonedOutputStream(os);
-
                     }
 
                     bytes = copyWithStats(is, os);
@@ -857,8 +855,32 @@ public class BrowserMobHttpClient {
             }
         }
 
+        BrowserMobHttpResponse output = new BrowserMobHttpResponse(entry, method, response, contentMatched, verificationText, errorMessage, responseBody, contentType, charSet);
 
-        return new BrowserMobHttpResponse(entry, method, response, contentMatched, verificationText, errorMessage, responseBody, contentType, charSet);
+        for (ResponseInterceptor interceptor : responseInterceptors) {
+            interceptor.process(output);
+        }
+
+        //TODO - is there a better way of doing this?
+        if (os != null && os instanceof ClonedOutputStream && captureContent ) {
+            try {
+                if ( !gzipping && (contentType.startsWith("text/")  ||
+                        contentType.startsWith("application/x-javascript")) ||
+                        contentType.startsWith("application/javascript")  ||
+                        contentType.startsWith("application/json")  ||
+                        contentType.startsWith("application/xml")  ||
+                        contentType.startsWith("application/xhtml+xml")) {
+                    ((ClonedOutputStream)os).writeAndCloseAll(output.getEntry().getResponse().getContent().getText());
+                }
+                else {
+                    ((ClonedOutputStream)os).writeAndCloseAll( ) ;
+                }
+            } catch (IOException e) {
+                e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+            }
+        }
+
+        return output ;
     }
 
     public void shutdown() {

--- a/src/main/java/net/lightbody/bmp/proxy/util/ClonedOutputStream.java
+++ b/src/main/java/net/lightbody/bmp/proxy/util/ClonedOutputStream.java
@@ -3,6 +3,7 @@ package net.lightbody.bmp.proxy.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 
 public class ClonedOutputStream extends OutputStream {
     private OutputStream os;
@@ -14,35 +15,55 @@ public class ClonedOutputStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        os.write(b);
+//        os.write(b);
         copy.write(b);
     }
 
     @Override
     public void write(byte[] b) throws IOException {
-        os.write(b);
+//        os.write(b);
         copy.write(b);
     }
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        os.write(b, off, len);
+//        os.write(b, off, len);
         copy.write(b, off, len);
     }
 
     @Override
     public void flush() throws IOException {
-        os.flush();
+//        os.flush();
         copy.flush();
     }
 
     @Override
     public void close() throws IOException {
-        os.close();
+//        os.close();
         copy.close();
     }
 
     public ByteArrayOutputStream getOutput() {
         return copy;
+    }
+
+    public void writeAndCloseAll( ) throws IOException {
+        writeAndCloseAll(null);
+    }
+    public void writeAndCloseAll(String in) throws IOException {
+        if ( in!= null ) {
+            if (copy.toString().equals(in) ){
+                copy.writeTo(os);
+            }
+            else {
+                PrintWriter out = new PrintWriter(os) ;
+                out.write(in);
+            }
+        }
+        else if (!copy.toString().isEmpty()) {
+            copy.writeTo(os);
+        }
+        os.flush();
+        os.close();
     }
 }

--- a/src/main/java/net/lightbody/bmp/proxy/util/ClonedOutputStream.java
+++ b/src/main/java/net/lightbody/bmp/proxy/util/ClonedOutputStream.java
@@ -1,9 +1,6 @@
 package net.lightbody.bmp.proxy.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
+import java.io.*;
 
 public class ClonedOutputStream extends OutputStream {
     private OutputStream os;
@@ -56,8 +53,10 @@ public class ClonedOutputStream extends OutputStream {
                 copy.writeTo(os);
             }
             else {
-                PrintWriter out = new PrintWriter(os) ;
+                OutputStreamWriter out = new OutputStreamWriter(os) ;
                 out.write(in);
+                out.flush();
+                out.close();
             }
         }
         else if (!copy.toString().isEmpty()) {


### PR DESCRIPTION
Apologies if this is not the right format. Its my first pull request. 

Below changes are made with the ability to intercept the response prior to it being served in mind. 

Changed classes: BrowserMobHttpClient.java and ClonedOutputStream. 

BrowserMobHttpClient:
Moved the check for ResponseInterceptor from execute(BrowserMobHttpRequest req)  to    execute(BrowserMobHttpRequest req, int dept). 
Added code to write from the ClonedOutputStream after interception. 

ClonedOutputStream:
Removed the pairing of OutputStream and ByteArrayOutputStream operations, storing in the array until later. This allows us to make a change to the stream before forwarding it. 

Notes: 
This only works for text code now. 

Please send back any feedback or suggestions to me, I havent really worked in this type of area before, so its all learning. 

Thanks
Andrew  