### PR TITLE
Honour the charset that comes with content/type=...;charset=foobar header when producing a HAR

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -745,7 +745,7 @@ public class BrowserMobHttpClient {
                         if (hasTextualContent(contentType)) {
                         	setTextOfEntry(entry, copy, contentType);
                         } else if(captureBinaryContent){
-                            entry.getResponse().getContent().setText(Base64.byteArrayToBase64(copy.toByteArray()));
+                            setBinaryContentOfEntry(entry, copy);
                         }
                     }
 
@@ -848,6 +848,11 @@ public class BrowserMobHttpClient {
 				contentType.startsWith("application/json")  ||
 				contentType.startsWith("application/xml")  ||
 				contentType.startsWith("application/xhtml+xml");
+	}
+
+	private void setBinaryContentOfEntry(HarEntry entry,
+			ByteArrayOutputStream copy) {
+		entry.getResponse().getContent().setText(Base64.byteArrayToBase64(copy.toByteArray()));
 	}
 
 	private void setTextOfEntry(HarEntry entry,


### PR DESCRIPTION
Hiya!

We stumbled into a problem when trying to get HARs that included csv files whose charset was not UTF-8, say latin1 or cp1252.  As it was, we would obtain an irreversibly damaged representation of the csv file that included lots of UTF-8 replacement characters, U+FFFD.

Thanks!
