### PR TITLE
Use empty strings instead of NULL for comments

### DIFF
--- a/src/main/java/net/lightbody/bmp/core/har/HarCacheStatus.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarCacheStatus.java
@@ -12,7 +12,7 @@ public class HarCacheStatus {
     private Date lastAccess;
     private String eTag;
     private int hitCount;
-    private String comment;
+    private String comment = "";
 
     @JsonSerialize(using = ISO8601DateFormatter.class)
     public Date getExpires() {

--- a/src/main/java/net/lightbody/bmp/core/har/HarContent.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarContent.java
@@ -9,7 +9,7 @@ public class HarContent {
     private String mimeType = "";
     private String text;
     private String encoding;
-    private String comment;
+    private String comment = "";
 
     public long getSize() {
         return size;

--- a/src/main/java/net/lightbody/bmp/core/har/HarCookie.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarCookie.java
@@ -15,7 +15,7 @@ public class HarCookie {
     private Date expires;
     private Boolean httpOnly;
     private Boolean secure;
-    private String comment;
+    private String comment = "";
 
     public String getName() {
         return name;

--- a/src/main/java/net/lightbody/bmp/core/har/HarEntry.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarEntry.java
@@ -18,7 +18,7 @@ public class HarEntry {
     private HarTimings timings;
     private String serverIPAddress;
     private String connection;
-    private String comment;
+    private String comment = "";
 
     public HarEntry() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarLog.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarLog.java
@@ -12,7 +12,7 @@ public class HarLog {
     private HarNameVersion browser;
     private List<HarPage> pages = new CopyOnWriteArrayList<HarPage>();
     private List<HarEntry> entries = new CopyOnWriteArrayList<HarEntry>();
-    private String comment;
+    private String comment = "";
 
     public HarLog() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarNameVersion.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarNameVersion.java
@@ -3,7 +3,7 @@ package net.lightbody.bmp.core.har;
 public class HarNameVersion {
     private String name;
     private String version;
-    private String comment;
+    private String comment = "";
 
     public HarNameVersion() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarPage.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarPage.java
@@ -11,7 +11,7 @@ public class HarPage {
     private Date startedDateTime;
     private String title = "";
     private HarPageTimings pageTimings = new HarPageTimings();
-    private String comment;
+    private String comment = "";
 
     public HarPage() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarPageTimings.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarPageTimings.java
@@ -6,7 +6,7 @@ import org.codehaus.jackson.annotate.JsonWriteNullProperties;
 public class HarPageTimings {
     private Long onContentLoad;
     private Long onLoad;
-    private String comment;
+    private String comment = "";
 
     public HarPageTimings() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarPostData.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarPostData.java
@@ -9,7 +9,7 @@ public class HarPostData {
     private String mimeType;
     private List<HarPostDataParam> params;
     private String text;
-    private String comment;
+    private String comment = "";
 
     public String getMimeType() {
         return mimeType;

--- a/src/main/java/net/lightbody/bmp/core/har/HarPostDataParam.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarPostDataParam.java
@@ -8,7 +8,7 @@ public class HarPostDataParam {
     private String value;
     private String fileName;
     private String contentType;
-    private String comment;
+    private String comment = "";
 
     public HarPostDataParam() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarRequest.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarRequest.java
@@ -16,7 +16,7 @@ public class HarRequest {
     private HarPostData postData;
     private long headersSize; // Odd grammar in spec
     private long bodySize;
-    private String comment;
+    private String comment = "";
 
     public HarRequest() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarResponse.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarResponse.java
@@ -16,7 +16,7 @@ public class HarResponse {
     private String redirectURL = "";
     private long headersSize;
     private long bodySize;
-    private String comment;
+    private String comment = "";
 
     public HarResponse() {
     }

--- a/src/main/java/net/lightbody/bmp/core/har/HarTimings.java
+++ b/src/main/java/net/lightbody/bmp/core/har/HarTimings.java
@@ -8,7 +8,7 @@ public class HarTimings {
     private long wait;
     private long receive;
     private long ssl;
-    private String comment;
+    private String comment = "";
 
     public HarTimings() {
     }


### PR DESCRIPTION
Fix for lightbody/browsermob-proxy#30

By default, set comments to empty string, as opposed to null.  See samples [described in spec](http://www.softwareishard.com/blog/har-12-spec/).
