### PR TITLE
add getters

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -334,4 +334,8 @@ public class ProxyServer {
             client.setHttpProxy(options.get("httpProxy"));
         }
     }
+    
+    public BrowserMobHttpClient getClient() {
+		return client;
+	}
 }

--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -1171,4 +1171,8 @@ public class BrowserMobHttpClient {
 
         return bytesCopied;
     }
+    
+    public DefaultHttpClient getHttpClient() {
+		return httpClient;
+	}
 }


### PR DESCRIPTION
Hi

The autoNTLMAuthorization(...) method of net.lightbody.bmp.proxy.http.BrowserMobHttpClient class is not accessible. For limiting code in BrowserMob i have create this patch for accessing to the DefaultHttpClient with a getter.
The attributes of browsermob-proxy are private and it's difficult to add specific functionnality. It should be better if attributes are protected or if for each attribute there is the getter/setter

Thanks
Sylvain
