### PR TITLE
RequestInterceptorTest + some cleanup of existing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk7

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/v-dev/browsermob-proxy.png?branch=request-interceptor-test)](https://travis-ci.org/v-dev/browsermob-proxy)
+
 BrowserMob Proxy
 ================
 

--- a/src/test/java/net/lightbody/bmp/proxy/DummyServerTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/DummyServerTest.java
@@ -4,7 +4,8 @@ import org.junit.After;
 import org.junit.Before;
 
 public abstract class DummyServerTest extends ProxyServerTest {
-    protected DummyServer dummy = new DummyServer(8080);
+    protected final int DUMMY_SERVER_PORT = 8080;
+    protected DummyServer dummy = new DummyServer(DUMMY_SERVER_PORT);
 
     @Before
     public void startServer() throws Exception {

--- a/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
@@ -8,16 +8,20 @@ import net.lightbody.bmp.proxy.http.BrowserMobHttpResponse;
 import net.lightbody.bmp.proxy.http.RequestInterceptor;
 import net.lightbody.bmp.proxy.http.ResponseInterceptor;
 import net.lightbody.bmp.proxy.util.IOUtils;
+import net.lightbody.bmp.proxy.util.Log;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
+import org.junit.After;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -35,8 +39,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
 public class MailingListIssuesTest extends DummyServerTest {
+    private static final Log LOG = new Log();
+
     private final String DUMMY_SERVER_BASE_URL = "http://127.0.0.1:" + DUMMY_SERVER_PORT;
     private final String DUMMY_SERVER_A_TXT = DUMMY_SERVER_BASE_URL + "/a.txt";
+
+    private WebDriver driver;
+
+    @After
+    public void shutdownWebDriver() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
 
     @Test
     public void testThatInterceptorIsCalled() throws IOException, InterruptedException {
@@ -163,9 +178,9 @@ public class MailingListIssuesTest extends DummyServerTest {
         HttpPost post = new HttpPost(DUMMY_SERVER_BASE_URL + "/jsonrpc/");
         HttpEntity entity = new StringEntity("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"test\",\"params\":{}}");
         post.setEntity(entity);
-    	post.addHeader("Accept", "application/json-rpc");
-    	post.addHeader("Content-Type", "application/json; charset=UTF-8");
-    
+        post.addHeader("Accept", "application/json-rpc");
+        post.addHeader("Content-Type", "application/json; charset=UTF-8");
+
         String body = IOUtils.readFully(client.execute(post).getEntity().getContent());
 
         Assert.assertTrue(body.contains("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
@@ -347,36 +362,39 @@ public class MailingListIssuesTest extends DummyServerTest {
 
         boolean postDataCapturedAndLoggedCorrectly = capturedPostData[0].equals(capturedPostData[1]);
 
-        Assert.assertEquals(true,postDataCapturedAndLoggedCorrectly);
+        Assert.assertEquals(true, postDataCapturedAndLoggedCorrectly);
 
     }
 
     @Test
-    public void issue27() throws Exception{
+    public void issue27() throws Exception {
         // see: https://github.com/lightbody/browsermob-proxy/issues/27
 
-        // start the proxy
-        ProxyServer server = new ProxyServer(4444);
-        server.start();
-        server.setCaptureHeaders(true);
-        server.setCaptureContent(true);
+        // configure the proxy
+        proxy.setCaptureHeaders(true);
+        proxy.setCaptureContent(true);
 
         // get the selenium proxy object
-        Proxy proxy = server.seleniumProxy();
+        Proxy seleniumProxy = proxy.seleniumProxy();
         DesiredCapabilities capabilities = new DesiredCapabilities();
 
-        capabilities.setCapability(CapabilityType.PROXY, proxy);
+        capabilities.setCapability(CapabilityType.PROXY, seleniumProxy);
 
-        // start the browser up
-        WebDriver driver = new FirefoxDriver(capabilities);
+        // start the browser up and skip if it can't find FireFox.
+        try {
+            driver = new FirefoxDriver(capabilities);
+        } catch (WebDriverException wde) {
+            LOG.warn("WebDriverException instantiating FirefoxDriver.  Browser is most likely not installed.  Skipping this test. ", wde);
+            Assume.assumeNoException(wde);
+        }
 
-        server.newHar("assertselenium.com");
+        proxy.newHar("assertselenium.com");
 
         driver.get("http://whatsmyuseragent.com");
         //driver.get("https://google.com");
 
         // get the HAR data
-        Har har = server.getHar();
+        Har har = proxy.getHar();
 
         // make sure something came back in the har
         Assert.assertTrue(!har.getLog().getEntries().isEmpty());
@@ -384,34 +402,34 @@ public class MailingListIssuesTest extends DummyServerTest {
         // show that we can capture the HTML of the root page
         String text = har.getLog().getEntries().get(0).getResponse().getContent().getText();
         Assert.assertTrue(text.contains("<title>Whats My User Agent?</title>"));
-
-        server.stop();
-        driver.quit();
     }
 
     @Test
-    public void googleCaSslNotWorkingInFirefox() throws Exception{
-        // start the proxy
-        ProxyServer server = new ProxyServer(4444);
-        server.start();
-        server.setCaptureHeaders(true);
-        server.setCaptureContent(true);
+    public void googleCaSslNotWorkingInFirefox() throws Exception {
+        // configure the proxy
+        proxy.setCaptureHeaders(true);
+        proxy.setCaptureContent(true);
 
         // get the selenium proxy object
-        Proxy proxy = server.seleniumProxy();
+        Proxy seleniumProxy = proxy.seleniumProxy();
         DesiredCapabilities capabilities = new DesiredCapabilities();
 
-        capabilities.setCapability(CapabilityType.PROXY, proxy);
+        capabilities.setCapability(CapabilityType.PROXY, seleniumProxy);
 
-        // start the browser up
-        WebDriver driver = new FirefoxDriver(capabilities);
+        // start the browser up and skip if it can't find FireFox.
+        try {
+            driver = new FirefoxDriver(capabilities);
+        } catch (WebDriverException wde) {
+            LOG.warn("WebDriverException instantiating FirefoxDriver.  Browser is most likely not installed.  Skipping this test. ", wde);
+            Assume.assumeNoException(wde);
+        }
 
-        server.newHar("Google.ca");
+        proxy.newHar("Google.ca");
 
         driver.get("https://www.google.ca/");
 
         // get the HAR data
-        Har har = server.getHar();
+        Har har = proxy.getHar();
 
         // make sure something came back in the har
         Assert.assertTrue(!har.getLog().getEntries().isEmpty());
@@ -419,10 +437,6 @@ public class MailingListIssuesTest extends DummyServerTest {
         // show that we can capture the HTML of the root page
         String text = har.getLog().getEntries().get(0).getResponse().getContent().getText();
         Assert.assertTrue(text.contains("<title>Google</title>"));
-
-        server.stop();
-        driver.quit();
     }
-
 
 }

--- a/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
@@ -35,6 +35,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
 public class MailingListIssuesTest extends DummyServerTest {
+    private final String DUMMY_SERVER_BASE_URL = "http://127.0.0.1:" + DUMMY_SERVER_PORT;
+    private final String DUMMY_SERVER_A_TXT = DUMMY_SERVER_BASE_URL + "/a.txt";
+
     @Test
     public void testThatInterceptorIsCalled() throws IOException, InterruptedException {
         final boolean[] interceptorHit = {false};
@@ -45,7 +48,7 @@ public class MailingListIssuesTest extends DummyServerTest {
             }
         });
 
-        String body = IOUtils.readFully(client.execute(new HttpGet("http://127.0.0.1:8080/a.txt")).getEntity().getContent());
+        String body = IOUtils.readFully(client.execute(new HttpGet(DUMMY_SERVER_A_TXT)).getEntity().getContent());
 
         Assert.assertTrue(body.contains("this is a.txt"));
         Assert.assertTrue(interceptorHit[0]);
@@ -61,7 +64,7 @@ public class MailingListIssuesTest extends DummyServerTest {
             }
         });
 
-        String body = IOUtils.readFully(client.execute(new HttpGet("http://127.0.0.1:8080/a.txt")).getEntity().getContent());
+        String body = IOUtils.readFully(client.execute(new HttpGet(DUMMY_SERVER_A_TXT)).getEntity().getContent());
 
         Assert.assertTrue(body.contains("this is a.txt"));
         Assert.assertEquals("Remote host incorrect", "127.0.0.1", remoteHost[0]);
@@ -77,7 +80,7 @@ public class MailingListIssuesTest extends DummyServerTest {
             }
         });
 
-        String body = IOUtils.readFully(client.execute(new HttpGet("http://127.0.0.1:8080/a.txt")).getEntity().getContent());
+        String body = IOUtils.readFully(client.execute(new HttpGet(DUMMY_SERVER_A_TXT)).getEntity().getContent());
 
         Assert.assertTrue(body.contains("this is a.txt"));
     }
@@ -88,14 +91,14 @@ public class MailingListIssuesTest extends DummyServerTest {
             @Override
             public void process(BrowserMobHttpRequest request, Har har) {
                 try {
-                    request.getMethod().setURI(new URI("http://127.0.0.1:8080/b.txt"));
+                    request.getMethod().setURI(new URI(DUMMY_SERVER_BASE_URL + "/b.txt"));
                 } catch (URISyntaxException e) {
                     e.printStackTrace();
                 }
             }
         });
 
-        String body = IOUtils.readFully(client.execute(new HttpGet("http://127.0.0.1:8080/a.txt")).getEntity().getContent());
+        String body = IOUtils.readFully(client.execute(new HttpGet(DUMMY_SERVER_A_TXT)).getEntity().getContent());
 
         Assert.assertTrue(body.contains("this is b.txt"));
     }
@@ -112,7 +115,7 @@ public class MailingListIssuesTest extends DummyServerTest {
             }
         });
 
-        String body = IOUtils.readFully(client.execute(new HttpGet("http://127.0.0.1:8080/a.txt")).getEntity().getContent());
+        String body = IOUtils.readFully(client.execute(new HttpGet(DUMMY_SERVER_A_TXT)).getEntity().getContent());
 
         ThreadUtils.waitFor(new ThreadUtils.WaitCondition() {
             @Override
@@ -129,7 +132,7 @@ public class MailingListIssuesTest extends DummyServerTest {
         proxy.setCaptureContent(true);
         proxy.newHar("Test");
 
-        String body = IOUtils.readFully(client.execute(new HttpGet("http://127.0.0.1:8080/a.txt")).getEntity().getContent());
+        String body = IOUtils.readFully(client.execute(new HttpGet(DUMMY_SERVER_A_TXT)).getEntity().getContent());
         System.out.println("Done with request");
 
         Assert.assertTrue(body.contains("this is a.txt"));
@@ -157,7 +160,7 @@ public class MailingListIssuesTest extends DummyServerTest {
         proxy.setCaptureContent(true);
         proxy.newHar("Test");
 
-        HttpPost post = new HttpPost("http://127.0.0.1:8080/jsonrpc/");
+        HttpPost post = new HttpPost(DUMMY_SERVER_BASE_URL + "/jsonrpc/");
         HttpEntity entity = new StringEntity("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"test\",\"params\":{}}");
         post.setEntity(entity);
     	post.addHeader("Accept", "application/json-rpc");
@@ -189,7 +192,7 @@ public class MailingListIssuesTest extends DummyServerTest {
         proxy.setCaptureContent(true);
         proxy.newHar("Test");
 
-        HttpPost post = new HttpPost("http://127.0.0.1:8080/jsonrpc/");
+        HttpPost post = new HttpPost(DUMMY_SERVER_BASE_URL + "/jsonrpc/");
         post.setEntity(new UrlEncodedFormEntity(Collections.singletonList(new BasicNameValuePair("foo", "bar"))));
 
         IOUtils.readFully(client.execute(post).getEntity().getContent());
@@ -219,7 +222,7 @@ public class MailingListIssuesTest extends DummyServerTest {
         proxy.setCaptureContent(true);
         proxy.newHar("Test");
 
-        InputStream is1 = client.execute(new HttpGet("http://127.0.0.1:8080/c.png")).getEntity().getContent();
+        InputStream is1 = client.execute(new HttpGet(DUMMY_SERVER_BASE_URL + "/c.png")).getEntity().getContent();
         ByteArrayOutputStream o1 = new ByteArrayOutputStream();
         IOUtils.copy(is1, o1);
         ByteArrayOutputStream o2 = new ByteArrayOutputStream();
@@ -251,7 +254,7 @@ public class MailingListIssuesTest extends DummyServerTest {
         proxy.setCaptureContent(true);
         proxy.newHar("Test");
 
-        HttpGet get = new HttpGet("http://127.0.0.1:8080/a.txt?foo=bar&a=1%262");
+        HttpGet get = new HttpGet(DUMMY_SERVER_A_TXT + "?foo=bar&a=1%262");
         client.execute(get);
 
         Har har = proxy.getHar();
@@ -283,7 +286,7 @@ public class MailingListIssuesTest extends DummyServerTest {
         dummy.getHandler().setMinGzipLength(1);
 
 
-        HttpGet get = new HttpGet("http://127.0.0.1:8080/a.txt");
+        HttpGet get = new HttpGet(DUMMY_SERVER_A_TXT);
         get.addHeader("Accept-Encoding", "gzip");
         String body = IOUtils.readFully(new GZIPInputStream(client.execute(get).getEntity().getContent()));
         System.out.println("Done with request");
@@ -324,7 +327,7 @@ public class MailingListIssuesTest extends DummyServerTest {
             }
         });
 
-        HttpPost post = new HttpPost("http://127.0.0.1:8080/echo/");
+        HttpPost post = new HttpPost(DUMMY_SERVER_BASE_URL + "/echo/");
         HttpEntity entity = new StringEntity("testParam=testValue");
         post.setEntity(entity);
         post.addHeader("Content-Type", "application/x-www-form-urlencoded");

--- a/src/test/java/net/lightbody/bmp/proxy/PhantomJSTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/PhantomJSTest.java
@@ -2,6 +2,8 @@ package net.lightbody.bmp.proxy;
 
 import junit.framework.Assert;
 import net.lightbody.bmp.core.har.Har;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
@@ -10,13 +12,28 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class PhantomJSTest {
-    @Test
-    public void basicBasic() throws Exception {
+    private final int PROXY_PORT = 4444;
+
+    private ProxyServer server;
+    private PhantomJSDriver driver;
+
+    @Before
+    public void before() throws Exception {
         // start the proxy
-        ProxyServer server = new ProxyServer(4444);
+        server = new ProxyServer(PROXY_PORT);
         server.start();
         server.setCaptureHeaders(true);
         server.setCaptureContent(true);
+    }
+
+    @After
+    public void after() throws Exception {
+        server.stop();
+        driver.quit();
+    }
+
+    @Test
+    public void basicBasic() throws Exception {
 
         // get the selenium proxy object
         Proxy proxy = server.seleniumProxy();
@@ -24,7 +41,7 @@ public class PhantomJSTest {
 
         capabilities.setCapability(CapabilityType.PROXY, proxy);
 
-        PhantomJSDriver driver = new PhantomJSDriver(capabilities);
+        driver = new PhantomJSDriver(capabilities);
 
         server.newHar("Yahoo");
 
@@ -39,30 +56,20 @@ public class PhantomJSTest {
         // show that we can capture the HTML of the root page
         String text = har.getLog().getEntries().get(0).getResponse().getContent().getText();
         Assert.assertTrue(text.contains("<title>Yahoo</title>"));
-
-        server.stop();
-        driver.quit();
-
     }
 
     @Test
     public void basicSsl() throws Exception {
-        // start the proxy
-        ProxyServer server = new ProxyServer(4444);
-        server.start();
-        server.setCaptureHeaders(true);
-        server.setCaptureContent(true);
-
         // get the selenium proxy object
         Proxy proxy = server.seleniumProxy();
         DesiredCapabilities capabilities = new DesiredCapabilities();
 
         capabilities.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
         capabilities.setCapability(CapabilityType.SUPPORTS_JAVASCRIPT, true);
-        capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[] {"--ignore-ssl-errors=true", "--ssl-protocol=any"});
+        capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[]{"--ignore-ssl-errors=true", "--ssl-protocol=any"});
         capabilities.setCapability(CapabilityType.PROXY, proxy);
 
-        PhantomJSDriver driver = new PhantomJSDriver(capabilities);
+        driver = new PhantomJSDriver(capabilities);
 
         server.newHar("Google");
 
@@ -77,9 +84,5 @@ public class PhantomJSTest {
         // show that we can capture the HTML of the root page
         String text = har.getLog().getEntries().get(0).getResponse().getContent().getText();
         Assert.assertTrue(text.contains("<title>Google</title>"));
-
-        server.stop();
-        driver.quit();
-
     }
 }

--- a/src/test/java/net/lightbody/bmp/proxy/ProxyServerTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/ProxyServerTest.java
@@ -25,7 +25,8 @@ public abstract class ProxyServerTest {
         Main.configureLogging();
     }
 
-    protected ProxyServer proxy = new ProxyServer(8081);
+    protected final int PROXY_PORT = 8081;
+    protected ProxyServer proxy = new ProxyServer(PROXY_PORT);
     protected DefaultHttpClient client = getNewHttpClient();
 
     @Before
@@ -42,7 +43,7 @@ public abstract class ProxyServerTest {
             sf.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
 
             HttpParams params = new BasicHttpParams();
-            params.setParameter(ConnRoutePNames.DEFAULT_PROXY, new HttpHost("127.0.0.1", 8081, "http"));
+            params.setParameter(ConnRoutePNames.DEFAULT_PROXY, new HttpHost("127.0.0.1", PROXY_PORT, "http"));
             HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
             HttpProtocolParams.setContentCharset(params, HTTP.UTF_8);
 

--- a/src/test/java/net/lightbody/bmp/proxy/RequestInterceptorTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/RequestInterceptorTest.java
@@ -4,17 +4,35 @@ import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.proxy.http.BrowserMobHttpRequest;
 import net.lightbody.bmp.proxy.http.RequestInterceptor;
 import net.lightbody.bmp.proxy.util.Log;
+import net.lightbody.bmp.proxy.util.TestSSLSocketFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.params.HttpProtocolParams;
+import org.apache.http.protocol.HTTP;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.KeyStore;
 
 import static org.junit.Assert.assertTrue;
 
@@ -31,7 +49,9 @@ public class RequestInterceptorTest {
     private BrowserMobHttpRequest interceptedRequest;
     private DefaultHttpClient client;
     private HttpHost target;
-    private HttpGet requestMethod;
+    private HttpRequestBase requestMethod;
+
+    enum Method {GET, POST}
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -56,18 +76,68 @@ public class RequestInterceptorTest {
     }
 
     @Test
-    public void testInterceptGetOfUknownHost() {
-        setupApacheHttpClient();
+    public void testInterceptGetOfUnknownHost() {
+        setupApacheHttpClient(Method.GET, "unknown.host");
         executeClientRequest();
+
+        LOG.info("getRequestLine: " + interceptedRequest.getProxyRequest().getRequestLine());
+
+        assertTrue("The intercepted request was null.", interceptedRequest != null);
+    }
+
+    @Test
+    public void testInterceptGetOfGoogleCaAllowAllHosts() {
+        setupApacheHttpClient(Method.GET, "www.google.ca", true, true);
+        executeClientRequest();
+
+        LOG.info("getRequestLine: " + interceptedRequest.getProxyRequest().getRequestLine());
+
+        assertTrue("The intercepted request was null.", interceptedRequest != null);
+    }
+
+    @Test
+    public void testInterceptGetOfGoogleCaNoHostNameVerifier() {
+        setupApacheHttpClient(Method.GET, "www.google.ca", true, false);
+        executeClientRequest();
+
+        //LOG.info("getRequestLine: " + interceptedRequest.getProxyRequest().getRequestLine());
 
         assertTrue("The intercepted request was null.", interceptedRequest != null);
     }
 
 
-    private void setupApacheHttpClient() {
-        target = new HttpHost("unknown.host");
-        requestMethod = new HttpGet("/");
-        client = new DefaultHttpClient();
+    private void setupApacheHttpClient(Method method, String host) {
+        setupApacheHttpClient(method, host, false, false);
+    }
+
+    private void setupApacheHttpClient(Method method, String host, boolean useSsl, boolean trustAllHosts) {
+
+        if (useSsl) {
+            target = new HttpHost(host, 443, "HTTPS");
+        } else {
+            target = new HttpHost(host);
+        }
+
+        if (trustAllHosts) {
+            client = createTrustingHttpClient();
+        } else {
+            client = new DefaultHttpClient();
+        }
+
+        switch (method) {
+            case POST:
+                requestMethod = new HttpPost("/");
+                StringEntity entity = null;
+                try {
+                    entity = new StringEntity("blah");
+                } catch (UnsupportedEncodingException e) {
+                    LOG.info("Error occurred setting string entity of apache HttpPost: ", e);
+                }
+                ((HttpPost)requestMethod).setEntity(entity);
+                break;
+            case GET:
+                requestMethod = new HttpGet("/");
+        }
 
         HttpHost pxy = new HttpHost("localhost", PROXY_SERVER_PORT);
         client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, pxy);
@@ -81,6 +151,32 @@ public class RequestInterceptorTest {
             LOG.info("IOException occurred: ", e);
         }
         return response;
+    }
+
+    // modified from ProxyServerTest
+    private DefaultHttpClient createTrustingHttpClient() {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+
+            SSLSocketFactory sf = new TestSSLSocketFactory(trustStore);
+            sf.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+            HttpParams params = new BasicHttpParams();
+            HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
+            HttpProtocolParams.setContentCharset(params, HTTP.UTF_8);
+
+            SchemeRegistry registry = new SchemeRegistry();
+            registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
+            registry.register(new Scheme("https", sf, 443));
+
+            ClientConnectionManager ccm = new ThreadSafeClientConnManager(params, registry);
+
+            return new DefaultHttpClient(ccm, params);
+        } catch (Exception e) {
+            LOG.info("Exception setting ALLOW_ALL_HOSTNAME_VERIFIER", e);
+            return new DefaultHttpClient();
+        }
     }
 
 }

--- a/src/test/java/net/lightbody/bmp/proxy/RequestInterceptorTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/RequestInterceptorTest.java
@@ -17,7 +17,6 @@ import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
@@ -133,7 +132,7 @@ public class RequestInterceptorTest {
                 } catch (UnsupportedEncodingException e) {
                     LOG.info("Error occurred setting string entity of apache HttpPost: ", e);
                 }
-                ((HttpPost)requestMethod).setEntity(entity);
+                ((HttpPost) requestMethod).setEntity(entity);
                 break;
             case GET:
                 requestMethod = new HttpGet("/");

--- a/src/test/java/net/lightbody/bmp/proxy/RequestInterceptorTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/RequestInterceptorTest.java
@@ -1,0 +1,86 @@
+package net.lightbody.bmp.proxy;
+
+import net.lightbody.bmp.core.har.Har;
+import net.lightbody.bmp.proxy.http.BrowserMobHttpRequest;
+import net.lightbody.bmp.proxy.http.RequestInterceptor;
+import net.lightbody.bmp.proxy.util.Log;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test of ProxyServer's RequestInterceptor behavior.
+ *
+ * @author v
+ */
+public class RequestInterceptorTest {
+    private static final Log LOG = new Log();
+
+    private static final int PROXY_SERVER_PORT = 8888;
+    private static ProxyServer proxyServer;
+    private BrowserMobHttpRequest interceptedRequest;
+    private DefaultHttpClient client;
+    private HttpHost target;
+    private HttpGet requestMethod;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        proxyServer = new ProxyServer(PROXY_SERVER_PORT);
+        proxyServer.start();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        proxyServer.stop();
+    }
+
+    @Before
+    public void setupRequestInterceptor() {
+        proxyServer.addRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public void process(BrowserMobHttpRequest request, Har har) {
+                LOG.info("intercepted request is: " + request);
+                interceptedRequest = request;
+            }
+        });
+    }
+
+    @Test
+    public void testInterceptGetOfUknownHost() {
+        setupApacheHttpClient();
+        executeClientRequest();
+
+        assertTrue("The intercepted request was null.", interceptedRequest != null);
+    }
+
+
+    private void setupApacheHttpClient() {
+        target = new HttpHost("unknown.host");
+        requestMethod = new HttpGet("/");
+        client = new DefaultHttpClient();
+
+        HttpHost pxy = new HttpHost("localhost", PROXY_SERVER_PORT);
+        client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, pxy);
+    }
+
+    private HttpResponse executeClientRequest() {
+        HttpResponse response = null;
+        try {
+            response = client.execute(target, requestMethod);
+        } catch (IOException e) {
+            LOG.info("IOException occurred: ", e);
+        }
+        return response;
+    }
+
+}

--- a/src/test/java/net/lightbody/bmp/proxy/ServerWithInterceptorMain.java
+++ b/src/test/java/net/lightbody/bmp/proxy/ServerWithInterceptorMain.java
@@ -1,0 +1,32 @@
+package net.lightbody.bmp.proxy;
+
+import net.lightbody.bmp.core.har.Har;
+import net.lightbody.bmp.proxy.http.BrowserMobHttpRequest;
+import net.lightbody.bmp.proxy.http.RequestInterceptor;
+import net.lightbody.bmp.proxy.util.Log;
+
+/**
+ * Just a class with a main() method to start the server in embedded mode.  Useful for putting in debug.
+ *
+ * @author v
+ */
+public class ServerWithInterceptorMain {
+
+    public static void main(String... args) throws Exception {
+
+        final Log LOG = new Log();
+
+        final int PROXY_SERVER_PORT = 8888;
+
+        ProxyServer proxyServer = new ProxyServer(PROXY_SERVER_PORT);
+        proxyServer.start();
+
+        proxyServer.addRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public void process(BrowserMobHttpRequest request, Har har) {
+                LOG.info("intercepted request is: " + request);
+                LOG.info("request line: " + request.getProxyRequest().getRequestLine());
+            }
+        });
+    }
+}

--- a/src/test/java/net/lightbody/bmp/proxy/ServerWithInterceptorMain.java
+++ b/src/test/java/net/lightbody/bmp/proxy/ServerWithInterceptorMain.java
@@ -6,7 +6,8 @@ import net.lightbody.bmp.proxy.http.RequestInterceptor;
 import net.lightbody.bmp.proxy.util.Log;
 
 /**
- * Just a class with a main() method to start the server in embedded mode.  Useful for putting in debug.
+ * Just a class with a main() method to start the server in embedded mode and a request interceptor.
+ * Useful for putting in debug.
  *
  * @author v
  */


### PR DESCRIPTION
- Created RequestInterceptorTest to show a null request interceptor behavior when there are SSL errors.

- Created ServerWithInterceptorMain so I can place embedded mode in debug.

- Hooked up to Travis CI, including adding the status to the top of README.md.  Once merged, this will probably need to be updated to use a different Travis CI build aside from my own?  Or simply remove it.

- Cleanup of existing tests:
  * Extracted some common/duplicate variables into constants such as port numbers and URLs
  * Minor refactor to make use of existing @Before & @After methods with startup/shutdown logic, or added them.
  * In order to run in CI which doesn't have FireFox, adding Junit Assume logic to skip the FireFox tests if it throws a WebDriverException.

Regarding skipping FF tests: A follow on could probably be done for environments which do not have PhantomJS.  Thankfully, it seems Travis CI has that.  And speaking of CI, what do you think of Travis CI?  I just ran across it.  I am more familiar with Jenkins and TeamCity, but am not aware of any free hosted services.  If you know of any, I can look into hooking it up for you.

-Verna