### PR TITLE
Fixes HarResultsTest on Windows

### DIFF
--- a/src/test/java/net/lightbody/bmp/proxy/HarResultsTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/HarResultsTest.java
@@ -1,13 +1,15 @@
 package net.lightbody.bmp.proxy;
 
+import java.util.List;
+
 import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.core.har.HarEntry;
 import net.lightbody.bmp.core.har.HarLog;
+
 import org.apache.http.client.methods.HttpGet;
+import static org.hamcrest.CoreMatchers.*;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.List;
 
 public class HarResultsTest extends DummyServerTest {
     @Test
@@ -28,7 +30,8 @@ public class HarResultsTest extends DummyServerTest {
 
         Assert.assertEquals(100, entry.getRequest().getHeadersSize());
         Assert.assertEquals(0, entry.getRequest().getBodySize());
-        Assert.assertEquals(227, entry.getResponse().getHeadersSize());
+        // 226 for Windows, 227 for other platforms? Can it be that simple?
+        Assert.assertThat((int)entry.getResponse().getHeadersSize(), anyOf(is(226),is(227)));
         Assert.assertEquals(13, entry.getResponse().getBodySize());
     }
 


### PR DESCRIPTION
The headers coming back from the server depend on which platform Jetty
is running on. From evidence on github and my own machine, it seems that
they're 226 bytes long on Win, and 227 elsewhere.

That being said, the sample size is very low, and it would be better to
calculate the expected header size as part of the test. But I'm not sure
I understand the intention behind the test well enough to do that.
