### PR TITLE
DataSift patchset

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ NodeJS bindings for browswermob-proxy are available [here](https://github.com/zz
 DataSift Tweaks
 ---------------
 
-We use BMP as a standalone proxy alongside our [Storyplayer](http://datasift.github.io/storyplayer/) test automation tool, and we've made a few tweaks to make the proxy easier to work with:
+We use BMP as a standalone proxy alongside our [Storyplayer](http://datasift.github.io/storyplayer/) test automation tool, and we've made a few tweaks to make the proxy easier to work with.
+
+All of our changes are advertised via the new /features API, and anything that affects backwards-compatibility has been switched off by default.  We use the /features API to help us warn users of Storyplayer if they need to upgrade their copy of browsermob-proxy - much more user-friendly than hitting a missing proxy endpoint partway through running a test!
+
+The full list of tweaks is:
 
 * POM file now builds browsermob-proxy-XXX-standalone.jar, which you can use to run browsermob-proxy from the command-line on any platform.
+* REST API: GET /features - returns a list of implemented extra features, and whether they are currently active or not

--- a/README.md
+++ b/README.md
@@ -220,3 +220,4 @@ The full list of tweaks is:
 
 * POM file now builds browsermob-proxy-XXX-standalone.jar, which you can use to run browsermob-proxy from the command-line on any platform.
 * REST API: GET /features - returns a list of implemented extra features, and whether they are currently active or not
+* REST API: POST / DELETE /features/requestLogs - enable / disable logging more info about the requests received by the proxy's REST API (very handy for building REST clients for the proxy)

--- a/README.md
+++ b/README.md
@@ -226,3 +226,4 @@ The full list of tweaks is:
 * REST API: PUT /proxy/:port/headers - drop the current set of injected headers, and replace with a new set
 * REST API: GET /proxy/:port/header/:name - get the value of an injected header
 * REST API: DELETE /proxy/:port/header/:name - delete a single injected header
+* All REST API handlers are now wrapped in try/catch blocks to ensure the proxy reports any serious errors back to any clients

--- a/README.md
+++ b/README.md
@@ -222,3 +222,7 @@ The full list of tweaks is:
 * REST API: GET /features - returns a list of implemented extra features, and whether they are currently active or not
 * REST API: POST / DELETE /features/requestLogs - enable / disable logging more info about the requests received by the proxy's REST API (very handy for building REST clients for the proxy)
 * REST API: POST / DELETE /features/enhancedReplies - enable / disable JSON replies containing explicit 'error' or 'success' info
+* REST API: DELETE /proxy/:port/headers - drop the current set of injected headers
+* REST API: PUT /proxy/:port/headers - drop the current set of injected headers, and replace with a new set
+* REST API: GET /proxy/:port/header/:name - get the value of an injected header
+* REST API: DELETE /proxy/:port/header/:name - delete a single injected header

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Once that is done, a new proxy will be available on the port returned. All you h
  - PUT /proxy/[port]/whitelist - Sets a list of URL patterns to whitelist. Takes the following parameters:
   - regex - a comma separated list of regular expressions
   - status - the HTTP status code to return for URLs that do not match the whitelist
- - DELETE /proxy/[port]/whitelist - Clears all URL patterns from the whitelist 
+ - DELETE /proxy/[port]/whitelist - Clears all URL patterns from the whitelist
  - PUT /proxy/[port]/blacklist - Set a URL to blacklist. Takes the following parameters:
   - regex - the blacklist regular expression
   - status - the HTTP status code to return for URLs that are blacklisted
@@ -76,7 +76,7 @@ Once that is done, a new proxy will be available on the port returned. All you h
   - Payload data should be json encoded username and password name/value pairs (ex: {"username": "myUsername", "password": "myPassword"}
  - PUT /proxy/[port]/wait - wait till all request are being made
   - quietPeriodInMs - Sets quiet period in milliseconds
-  - timeoutInMs - Sets timeout in milliseconds 
+  - timeoutInMs - Sets timeout in milliseconds
  - PUT /proxy/[port]/timeout - Handles different proxy timeouts. Takes the following parameters:
   - requestTimeout - request timeout in milliseconds. A timeout value of -1 is interpreted as infinite timeout. It equals -1 by default.
   - readTimeout - read timeout in milliseconds. Which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. It equals 60000 by default
@@ -207,3 +207,11 @@ NodeJS Support
 --------------
 
 NodeJS bindings for browswermob-proxy are available [here](https://github.com/zzo/browsermob-node).  Built-in support for [Selenium](http://seleniumhq.org) or use [CapserJS-on-PhantomJS](http://casperjs.org) or anything else to drive traffic for HAR generation.
+
+
+DataSift Tweaks
+---------------
+
+We use BMP as a standalone proxy alongside our [Storyplayer](http://datasift.github.io/storyplayer/) test automation tool, and we've made a few tweaks to make the proxy easier to work with:
+
+* POM file now builds browsermob-proxy-XXX-standalone.jar, which you can use to run browsermob-proxy from the command-line on any platform.

--- a/README.md
+++ b/README.md
@@ -221,3 +221,4 @@ The full list of tweaks is:
 * POM file now builds browsermob-proxy-XXX-standalone.jar, which you can use to run browsermob-proxy from the command-line on any platform.
 * REST API: GET /features - returns a list of implemented extra features, and whether they are currently active or not
 * REST API: POST / DELETE /features/requestLogs - enable / disable logging more info about the requests received by the proxy's REST API (very handy for building REST clients for the proxy)
+* REST API: POST / DELETE /features/enhancedReplies - enable / disable JSON replies containing explicit 'error' or 'success' info

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
@@ -138,10 +143,88 @@
                     </execution>
                 </executions>
             </plugin>
+           <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.7.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>standalone</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>net.lightbody.bmp.proxy.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>false</addHeader>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>appassembler-maven-plugin</artifactId>
+                <version>1.1.1</version>
+                <configuration>
+                    <repositoryLayout>flat</repositoryLayout>
+                    <repositoryName>lib</repositoryName>
+                    <programs>
+                        <program>
+                            <mainClass>net.lightbody.bmp.proxy.Main</mainClass>
+                            <name>browsermob-proxy</name>
+                        </program>
+                    </programs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>assemble</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-    <dependencies>
 
+    <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
+++ b/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
@@ -6,12 +6,17 @@ public class FeatureFlags {
     private boolean requestLogs = false;
     private boolean enhancedReplies = false;
     private boolean headerGetDelete = true;
+    private boolean authBasic = true;
 
     /**
      * private constructor
      */
     private FeatureFlags() {
 
+    }
+
+    public boolean getAuthBasic() {
+        return this.authBasic;
     }
 
     public boolean getEnhancedReplies() {

--- a/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
+++ b/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
@@ -3,6 +3,7 @@ package net.lightbody.bmp.proxy;
 public class FeatureFlags {
 
     private boolean featureFlags = true;
+    private boolean requestLogs = false;
 
     /**
      * private constructor
@@ -13,6 +14,14 @@ public class FeatureFlags {
 
     public boolean getFeatureFlags() {
         return this.featureFlags;
+    }
+
+    public boolean getRequestLogs() {
+        return this.requestLogs;
+    }
+
+    public void setRequestLogs(boolean requestLogs) {
+        this.requestLogs = requestLogs;
     }
 
     public static FeatureFlags getInstance() {

--- a/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
+++ b/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
@@ -1,0 +1,27 @@
+package net.lightbody.bmp.proxy;
+
+public class FeatureFlags {
+
+    private boolean featureFlags = true;
+
+    /**
+     * private constructor
+     */
+    private FeatureFlags() {
+
+    }
+
+    public boolean getFeatureFlags() {
+        return this.featureFlags;
+    }
+
+    public static FeatureFlags getInstance() {
+        FeatureFlags instance = null;
+
+        if (instance == null) {
+            instance = new FeatureFlags();
+        }
+
+        return instance;
+    }
+}

--- a/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
+++ b/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
@@ -4,12 +4,21 @@ public class FeatureFlags {
 
     private boolean featureFlags = true;
     private boolean requestLogs = false;
+    private boolean enhancedReplies = false;
 
     /**
      * private constructor
      */
     private FeatureFlags() {
 
+    }
+
+    public boolean getEnhancedReplies() {
+        return this.enhancedReplies;
+    }
+
+    public void setEnhancedReplies(boolean enhancedReplies) {
+        this.enhancedReplies = enhancedReplies;
     }
 
     public boolean getFeatureFlags() {

--- a/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
+++ b/src/main/java/net/lightbody/bmp/proxy/FeatureFlags.java
@@ -5,6 +5,7 @@ public class FeatureFlags {
     private boolean featureFlags = true;
     private boolean requestLogs = false;
     private boolean enhancedReplies = false;
+    private boolean headerGetDelete = true;
 
     /**
      * private constructor
@@ -23,6 +24,10 @@ public class FeatureFlags {
 
     public boolean getFeatureFlags() {
         return this.featureFlags;
+    }
+
+    public boolean getHeaderGetDelete() {
+        return this.headerGetDelete;
     }
 
     public boolean getRequestLogs() {

--- a/src/main/java/net/lightbody/bmp/proxy/Main.java
+++ b/src/main/java/net/lightbody/bmp/proxy/Main.java
@@ -4,6 +4,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.servlet.GuiceServletContextListener;
 import com.google.sitebricks.SitebricksModule;
+import net.lightbody.bmp.proxy.bricks.ProxyFeatures;
 import net.lightbody.bmp.proxy.bricks.ProxyResource;
 import net.lightbody.bmp.proxy.guice.ConfigModule;
 import net.lightbody.bmp.proxy.guice.JettyModule;
@@ -37,6 +38,7 @@ public class Main {
         final Injector injector = Guice.createInjector(new ConfigModule(args), new JettyModule(), new SitebricksModule() {
             @Override
             protected void configureSitebricks() {
+                scan(ProxyFeatures.class.getPackage());
                 scan(ProxyResource.class.getPackage());
             }
         });

--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -248,7 +248,7 @@ public class ProxyServer {
     public void rewriteUrl(String match, String replace) {
         client.rewriteUrl(match, replace);
     }
-    
+
     public void clearRewriteRules() {
     	client.clearRewriteRules();
     }
@@ -256,7 +256,7 @@ public class ProxyServer {
     public void blacklistRequests(String pattern, int responseCode) {
         client.blacklistRequests(pattern, responseCode);
     }
-    
+
     public void clearBlacklist() {
     	client.clearBlacklist();
     }
@@ -264,13 +264,25 @@ public class ProxyServer {
     public void whitelistRequests(String[] patterns, int responseCode) {
         client.whitelistRequests(patterns, responseCode);
     }
-    
+
     public void clearWhitelist() {
     	client.clearWhitelist();
     }
 
     public void addHeader(String name, String value) {
         client.addHeader(name, value);
+    }
+
+    public String getHeader(String name) {
+        return client.getHeader(name);
+    }
+
+    public void removeHeader(String name) {
+        client.removeHeader(name);
+    }
+
+    public void removeAllHeaders() {
+        client.removeAllHeaders();
     }
 
     public void setCaptureHeaders(boolean captureHeaders) {
@@ -280,7 +292,7 @@ public class ProxyServer {
     public void setCaptureContent(boolean captureContent) {
         client.setCaptureContent(captureContent);
     }
-    
+
     public void setCaptureBinaryContent(boolean captureBinaryContent) {
         client.setCaptureBinaryContent(captureBinaryContent);
     }
@@ -317,7 +329,7 @@ public class ProxyServer {
                         lastCompleted = end;
                     }
                 }
-                
+
                 return lastCompleted != null && System.currentTimeMillis() - lastCompleted.getTime() >= quietPeriodInMs;
             }
         }, TimeUnit.MILLISECONDS, timeoutInMs);

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/BaseBrick.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/BaseBrick.java
@@ -1,0 +1,96 @@
+package net.lightbody.bmp.proxy.bricks;
+
+import com.google.sitebricks.client.transport.Json;
+import com.google.sitebricks.headless.Reply;
+import net.lightbody.bmp.proxy.util.Log;
+import net.lightbody.bmp.proxy.FeatureFlags;
+
+public class BaseBrick {
+
+    protected static FeatureFlags featureFlags = FeatureFlags.getInstance();
+
+    protected static final Log LOG = new Log();
+
+
+    public static class BrickEmptySuccessReply {
+        private boolean success = true;
+
+        public boolean getSuccess() {
+            return this.success;
+        }
+    }
+
+    public static class BrickSuccessReply {
+        private boolean success = true;
+        private Object data = null;
+
+        public BrickSuccessReply() {
+        }
+
+        public boolean getSuccess() {
+            return this.success;
+        }
+
+        public Object getData() {
+            return this.data;
+        }
+
+        public void setData(Object data) {
+            this.data = data;
+        }
+    }
+
+    public static class BrickErrorReply {
+        private boolean error = true;
+        private Object  data  = null;
+
+        public BrickErrorReply() {
+        }
+
+        public boolean getError() {
+            return this.error;
+        }
+
+        public Object getData() {
+            return this.data;
+        }
+
+        public void setData(Object data) {
+            this.data = data;
+        }
+    }
+
+    protected Reply<?> wrapSuccess(Object data) {
+        if (!this.getEnhancedReplies()) {
+            return Reply.with(data).as(Json.class);
+        }
+
+        BrickSuccessReply restReply = new BrickSuccessReply();
+        restReply.setData(data);
+
+        return Reply.with(restReply).as(Json.class);
+    }
+
+    protected Reply<?> wrapEmptySuccess() {
+        if (!this.getEnhancedReplies()) {
+            return Reply.saying().ok();
+        }
+
+        return Reply.with(new BrickEmptySuccessReply()).as(Json.class);
+    }
+
+    protected Reply<?> wrapError(Object data) {
+        if (!this.getEnhancedReplies()) {
+            return Reply.with(data).as(Json.class).error();
+        }
+
+        BrickErrorReply restReply = new BrickErrorReply();
+        restReply.setData(data);
+
+        return Reply.with(restReply).as(Json.class).error();
+    }
+
+    protected boolean getEnhancedReplies() {
+        return false;
+    }
+}

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/BaseBrick.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/BaseBrick.java
@@ -93,4 +93,28 @@ public class BaseBrick {
     protected boolean getEnhancedReplies() {
         return false;
     }
+
+    protected void logRequest(String path) {
+        if (!featureFlags.getRequestLogs()) {
+            return;
+        }
+
+        LOG.info(path);
+    }
+
+    protected void logRequest(String path, Object... args) {
+        if (!featureFlags.getRequestLogs()) {
+            return;
+        }
+
+        LOG.info(path, args);
+    }
+
+    protected void logParam(String name, Object param) {
+        if (!featureFlags.getRequestLogs()) {
+            return;
+        }
+
+        LOG.info("  PARAM: {} = {}", name, param);
+    }
 }

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/BaseBrick.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/BaseBrick.java
@@ -60,6 +60,22 @@ public class BaseBrick {
         }
     }
 
+    public static class BrickNotFoundReply {
+        private boolean error = true;
+        private String  message = "no such proxy";
+
+        public BrickNotFoundReply() {
+        }
+
+        public boolean getError() {
+            return this.error;
+        }
+
+        public String getMessage() {
+            return this.message;
+        }
+    }
+
     protected Reply<?> wrapSuccess(Object data) {
         if (!this.getEnhancedReplies()) {
             return Reply.with(data).as(Json.class);
@@ -71,12 +87,32 @@ public class BaseBrick {
         return Reply.with(restReply).as(Json.class);
     }
 
+    protected Reply<?> wrapNotFound() {
+        if (!this.getEnhancedReplies()) {
+            return Reply.saying().notFound();
+        }
+
+        BrickNotFoundReply restReply = new BrickNotFoundReply();
+
+        return Reply.with(restReply).as(Json.class).status(404);
+    }
+
     protected Reply<?> wrapEmptySuccess() {
         if (!this.getEnhancedReplies()) {
             return Reply.saying().ok();
         }
 
-        return Reply.with(new BrickEmptySuccessReply()).as(Json.class);
+        return Reply.saying().ok()
+                    .with(new BrickEmptySuccessReply()).as(Json.class);
+    }
+
+    protected Reply<?> wrapNoContent() {
+        if (!this.getEnhancedReplies()) {
+            return Reply.saying().noContent();
+        }
+
+        return Reply.saying().noContent()
+                    .with(new BrickEmptySuccessReply()).as(Json.class);
     }
 
     protected Reply<?> wrapError(Object data) {
@@ -91,7 +127,7 @@ public class BaseBrick {
     }
 
     protected boolean getEnhancedReplies() {
-        return false;
+        return featureFlags.getEnhancedReplies();
     }
 
     protected void logRequest(String path) {

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyFeatures.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyFeatures.java
@@ -16,11 +16,42 @@ public class ProxyFeatures extends BaseBrick {
 
     @Get
     public Reply<?> getFeatures() {
+        this.logRequest("GET /features");
+
         try {
             return(this.wrapSuccess(featureFlags));
         }
         catch (Exception e) {
             return this.wrapError(e);
         }
+    }
+
+    @Post
+    @At("/requestLogs")
+    public Reply<?> setRequestLogs(Request request) {
+        this.logRequest("POST /features/requestLogs");
+
+        String rawParam = request.param("requestLogs");
+        if (rawParam == null)
+        {
+            return this.wrapError("Missing param requestLogs");
+        }
+
+        Boolean requestLogs = Boolean.parseBoolean(rawParam);
+        this.logParam("requestLogs", requestLogs);
+
+        featureFlags.setRequestLogs(requestLogs);
+
+        return this.wrapEmptySuccess();
+    }
+
+    @Delete
+    @At("/requestLogs")
+    public Reply<?> deleteRequestLogs() {
+        this.logRequest("DELETE /features/requestLogs");
+
+        featureFlags.setRequestLogs(false);
+
+        return this.wrapEmptySuccess();
     }
 }

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyFeatures.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyFeatures.java
@@ -27,6 +27,35 @@ public class ProxyFeatures extends BaseBrick {
     }
 
     @Post
+    @At("/enhancedReplies")
+    public Reply<?> setEnhancedReplies(Request request) {
+        this.logRequest("POST /features/enhancedReplies");
+
+        String rawParam = request.param("enhancedReplies");
+        if (rawParam == null)
+        {
+            return this.wrapError("Missing param enhancedReplies");
+        }
+
+        Boolean enhancedReplies = Boolean.parseBoolean(rawParam);
+        this.logParam("enhancedReplies", enhancedReplies);
+
+        featureFlags.setEnhancedReplies(enhancedReplies);
+
+        return this.wrapEmptySuccess();
+    }
+
+    @Delete
+    @At("/enhancedReplies")
+    public Reply<?> deleteEnhancedReplies() {
+        this.logRequest("DELETE /features/enhancedReplies");
+
+        featureFlags.setEnhancedReplies(false);
+
+        return this.wrapEmptySuccess();
+    }
+
+    @Post
     @At("/requestLogs")
     public Reply<?> setRequestLogs(Request request) {
         this.logRequest("POST /features/requestLogs");

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyFeatures.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyFeatures.java
@@ -1,0 +1,26 @@
+package net.lightbody.bmp.proxy.bricks;
+
+import com.google.sitebricks.At;
+import com.google.sitebricks.headless.Reply;
+import com.google.sitebricks.headless.Request;
+import com.google.sitebricks.headless.Service;
+import com.google.sitebricks.http.Delete;
+import com.google.sitebricks.http.Get;
+import com.google.sitebricks.http.Post;
+
+import net.lightbody.bmp.proxy.FeatureFlags;
+
+@At("/features")
+@Service
+public class ProxyFeatures extends BaseBrick {
+
+    @Get
+    public Reply<?> getFeatures() {
+        try {
+            return(this.wrapSuccess(featureFlags));
+        }
+        catch (Exception e) {
+            return this.wrapError(e);
+        }
+    }
+}

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -250,6 +250,71 @@ public class ProxyResource extends BaseBrick {
         return this.wrapEmptySuccess();
     }
 
+    @Put
+    @At("/:port/headers")
+    public Reply<?> setHeaders(@Named("port") int port, Request request) {
+        this.logRequest("PUT /proxy/{}/headers", port);
+
+        ProxyServer proxy = proxyManager.get(port);
+        if (proxy == null) {
+            return this.wrapNotFound();
+        }
+
+        proxy.removeAllHeaders();
+
+        Map<String, String> headers = request.read(Map.class).as(Json.class);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            this.logParam(key, value);
+            proxy.addHeader(key, value);
+        }
+        return this.wrapEmptySuccess();
+    }
+
+    @Delete
+    @At("/:port/headers")
+    public Reply<?> removeAllHeaders(@Named("port") int port, Request request) {
+        this.logRequest("DELETE /proxy/{}/headers", port);
+
+        ProxyServer proxy = proxyManager.get(port);
+        if (proxy == null) {
+            return this.wrapNotFound();
+        }
+
+        proxy.removeAllHeaders();
+
+        return this.wrapEmptySuccess();
+    }
+
+    @Get
+    @At("/:port/header/:name")
+    public Reply<?> getHeader(@Named("port") int port, @Named("name") String name, Request request) {
+        this.logRequest("GET /proxy/{}/header/{}", port, name);
+
+        ProxyServer proxy = proxyManager.get(port);
+        if (proxy == null) {
+            return this.wrapNotFound();
+        }
+
+        return this.wrapSuccess(proxy.getHeader(name));
+    }
+
+    @Delete
+    @At("/:port/header/:name")
+    public Reply<?> removeHeader(@Named("port") int port, @Named("name") String name, Request request) {
+        this.logRequest("DELETE /proxy/{}/header/{}", port, name);
+
+        ProxyServer proxy = proxyManager.get(port);
+        if (proxy == null) {
+            return this.wrapNotFound();
+        }
+
+        proxy.removeHeader(name);
+
+        return this.wrapEmptySuccess();
+      }
+
     @Post
     @At("/:port/interceptor/response")
     public Reply<?> addResponseInterceptor(@Named("port") int port, Request request) throws IOException, ScriptException {

--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -869,7 +869,7 @@ public class BrowserMobHttpClient {
 		}
 	}
 
-    
+
     public void shutdown() {
         shutdown = true;
         abortActiveRequests();
@@ -965,9 +965,27 @@ public class BrowserMobHttpClient {
     	// synchronized to guard against concurrent modification
     	whitelistEntry = null;
     }
-    
+
     public void addHeader(String name, String value) {
         additionalHeaders.put(name, value);
+    }
+
+    public String getHeader(String name) {
+        if (additionalHeaders.containsKey(name)) {
+            return additionalHeaders.get(name);
+        }
+
+        return null;
+    }
+
+    public void removeHeader(String name) {
+        if (additionalHeaders.containsKey(name)) {
+            additionalHeaders.remove(name);
+        }
+    }
+
+    public void removeAllHeaders() {
+        additionalHeaders.clear();
     }
 
     public void prepareForBrowser() {


### PR DESCRIPTION
This PR contains DataSift's set of patches that we use when browsermob-proxy is distributed with [Storyplayer](http://datasift.github.io/storyplayer), our open-source test automation tool.  We use BMP as a standalone proxy server in conjunction with the Selenium standalone server.  The focus of our changes is on working with BMP exclusively via the built-in REST API.

All changes in this patchset should be completely backwards-compatible with the upstream distribution of BMP; where the changes break b/c, they have to be enabled via the new /features REST API.

* New: pom.xml now builds an executable JAR file too
* New: /features API to discover what a running instance of BMP can do
* New: 'requestLogs' feature to log more information to the console
* New: 'enhancedReplies' feature to wrap API responses in error / success container
* New: additional REST API calls for editing the list of injected request headers
* New: ProxyResource try/catch wrapping to report any unanticipated internal errors back to the BMP client