### PR TITLE
Improved auto-fetch of PhantomJS if absent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,35 +138,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <!-- Fetch PhantomJS for us -->
-            	<groupId>com.github.klieber</groupId>
-            	<artifactId>phantomjs-maven-plugin</artifactId>
-            	<version>0.2.1</version>
-            	<executions>
-            		<execution>
-            			<id>fetch-phantom-js</id>
-            			<goals>
-            				<goal>install</goal>
-            			</goals>
-            		</execution>
-            	</executions>
-				<configuration>
-					<!-- Fetch this version of PhantomJS -->
-					<version>1.9.2</version>
-        		</configuration>
-            </plugin>
-            <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
-				<configuration>
-					<!-- Make downloaded PhantomJS available to tests -->
-					<systemPropertyVariables>
-						<phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
-					</systemPropertyVariables>
-				</configuration>
-     		</plugin>
         </plugins>
     </build>
     <dependencies>
@@ -300,6 +271,11 @@
             <version>2013.10</version>
         </dependency>
 
+        <dependency>
+        	<groupId>org.jboss.arquillian.extension</groupId>
+        	<artifactId>arquillian-phantom-driver</artifactId>
+        	<version>1.1.1.Final</version>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/test/java/net/lightbody/bmp/proxy/PhantomJSTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/PhantomJSTest.java
@@ -4,6 +4,7 @@ import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.core.har.HarEntry;
 
 import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.phantom.resolver.ResolvingPhantomJSDriverService;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,7 +45,11 @@ public class PhantomJSTest {
 
         capabilities.setCapability(CapabilityType.PROXY, proxy);
 
-        PhantomJSDriver driver = new PhantomJSDriver(capabilities);
+        // ResolvingPhantomJSDriverService downloads PhantomJS if it's not found
+		PhantomJSDriver driver = new PhantomJSDriver(
+				ResolvingPhantomJSDriverService
+						.createDefaultService(capabilities),
+				capabilities);
         
         try {
             server.newHar("Yahoo");
@@ -78,7 +83,12 @@ public class PhantomJSTest {
         capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[] {"--ignore-ssl-errors=true", "--ssl-protocol=any"});
         capabilities.setCapability(CapabilityType.PROXY, proxy);
 
-        PhantomJSDriver driver = new PhantomJSDriver(capabilities);
+        // ResolvingPhantomJSDriverService downloads PhantomJS if it's not found
+		PhantomJSDriver driver = new PhantomJSDriver(
+				ResolvingPhantomJSDriverService
+						.createDefaultService(capabilities),
+				capabilities);
+		
         try {
             server.newHar("Google");
     


### PR DESCRIPTION
Now using Arquillian Phantom Driver that fetches PhantomJS from a maven
repo, instead of requiring a direct download. This should help people
behind proxies, etc. and hopefully solve any other PhantomJS fetching problems
I may have introduced.

This new driver also allows for local PhantomJS installations to
override the fetched one. So, people who have PhantomJS on their path,
for example, will see that one used instead of a downloaded one.

The test code itself requires a small change to include the
ResolvingPhantomJSDriverService, responsible for figuring out whether
to fetch a PhantomJS instance, or use an existing one.
