### PR TITLE
Support a parameter pageRef in getHar(). Also available in REST API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ Once that is done, a new proxy will be available on the port returned. All you h
  - PUT /proxy/[port]/har/pageRef - starts a new page on the existing HAR. Supports the following parameters:
   - pageRef - the string name of the first page ref that should be used in the HAR. Defaults to "Page N" where N is the next page number.
  - DELETE /proxy/[port] - shuts down the proxy and closes the port
- - GET /proxy/[port]/har - returns the JSON/HAR content representing all the HTTP traffic passed through the proxy
+ - GET /proxy/[port]/har - returns the JSON/HAR content representing all the HTTP traffic passed through the proxy. Supports the following parameters:
+  - pageRef - a comma separated list of pageRefs to retrieve. If omitted all the pageRefs will be returned.
  - PUT /proxy/[port]/whitelist - Sets a list of URL patterns to whitelist. Takes the following parameters:
   - regex - a comma separated list of regular expressions
   - status - the HTTP status code to return for URLs that do not match the whitelist
- - DELETE /proxy/[port]/whitelist - Clears all URL patterns from the whitelist 
+ - DELETE /proxy/[port]/whitelist - Clears all URL patterns from the whitelist
  - PUT /proxy/[port]/blacklist - Set a URL to blacklist. Takes the following parameters:
   - regex - the blacklist regular expression
   - status - the HTTP status code to return for URLs that are blacklisted
@@ -76,7 +77,7 @@ Once that is done, a new proxy will be available on the port returned. All you h
   - Payload data should be json encoded username and password name/value pairs (ex: {"username": "myUsername", "password": "myPassword"}
  - PUT /proxy/[port]/wait - wait till all request are being made
   - quietPeriodInMs - Sets quiet period in milliseconds
-  - timeoutInMs - Sets timeout in milliseconds 
+  - timeoutInMs - Sets timeout in milliseconds
  - PUT /proxy/[port]/timeout - Handles different proxy timeouts. Takes the following parameters:
   - requestTimeout - request timeout in milliseconds. A timeout value of -1 is interpreted as infinite timeout. It equals -1 by default.
   - readTimeout - read timeout in milliseconds. Which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. It equals 60000 by default

--- a/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHar.java
+++ b/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHar.java
@@ -1,0 +1,9 @@
+package net.lightbody.bmp.core.har;
+
+import java.util.Set;
+
+public class PageRefFilteredHar extends Har {
+    public PageRefFilteredHar(Har har, Set<String> pageRef) {
+        super(new PageRefFilteredHarLog(har.getLog(), pageRef));
+    }
+}

--- a/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHarLog.java
+++ b/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHarLog.java
@@ -1,0 +1,39 @@
+package net.lightbody.bmp.core.har;
+
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+public class PageRefFilteredHarLog extends HarLog {
+    public PageRefFilteredHarLog(HarLog log, Set<String> pageRef) {
+        super(log.getCreator());
+        setVersion(log.getVersion());
+        setBrowser(log.getBrowser());
+        setPages(getFilteredPages(log.getPages(), pageRef));
+        setEntries(getFilteredEntries(log.getEntries(), pageRef));
+        setComment(log.getComment());
+    }
+
+    private static List<HarPage> getFilteredPages(List<HarPage> pages, Set<String> pageRef) {
+        List<HarPage> filteredPages = new CopyOnWriteArrayList<HarPage>();
+        for (HarPage page : pages) {
+            if (pageRef.contains(page.getId())) {
+                filteredPages.add(page);
+            }
+        }
+        return filteredPages;
+    }
+
+    private static List<HarEntry> getFilteredEntries(List<HarEntry> entries, Set<String> pageRef) {
+        List<HarEntry> filteredEntries = new CopyOnWriteArrayList<HarEntry>();
+        for (HarEntry entry : entries) {
+            if (pageRef.contains(entry.getPageref())) {
+                filteredEntries.add(entry);
+            }
+        }
+        return filteredEntries;
+    }
+}

--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -24,6 +24,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -109,10 +110,10 @@ public class ProxyServer {
 
     /**
      * Get the the InetAddress that the Proxy server binds to when it starts.
-     * 
+     *
      * If not otherwise set via {@link #setLocalHost(InetAddress)}, defaults to
      * 0.0.0.0 (i.e. bind to any interface).
-     * 
+     *
      * Note - just because we bound to the address, doesn't mean that it can be
      * reached. E.g. trying to connect to 0.0.0.0 is going to fail. Use
      * {@link #getConnectableLocalHost()} if you're looking for a host that can be
@@ -124,16 +125,16 @@ public class ProxyServer {
         }
         return localHost;
     }
-    
+
     /**
      * Return a plausible {@link InetAddress} that other processes can use to
      * contact the proxy.
-     * 
+     *
      * In essence, this is the same as {@link #getLocalHost()}, but avoids
      * returning 0.0.0.0. as no-one can connect to that. If no other host has
      * been set via {@link #setLocalHost(InetAddress)}, will return
      * {@link InetAddress#getLocalHost()}
-     * 
+     *
      * No attempt is made to check the address for reachability before it is
      * returned.
      */
@@ -173,6 +174,10 @@ public class ProxyServer {
         }
 
         return client.getHar();
+    }
+
+    public Har getHar(Set<String> pageRef) {
+        return new PageRefFilteredHar(getHar(), pageRef);
     }
 
     public Har newHar(String initialPageRef) {
@@ -279,7 +284,7 @@ public class ProxyServer {
     public void rewriteUrl(String match, String replace) {
         client.rewriteUrl(match, replace);
     }
-    
+
     public void clearRewriteRules() {
     	client.clearRewriteRules();
     }
@@ -287,7 +292,7 @@ public class ProxyServer {
     public void blacklistRequests(String pattern, int responseCode) {
         client.blacklistRequests(pattern, responseCode);
     }
-    
+
     public void clearBlacklist() {
     	client.clearBlacklist();
     }
@@ -295,7 +300,7 @@ public class ProxyServer {
     public void whitelistRequests(String[] patterns, int responseCode) {
         client.whitelistRequests(patterns, responseCode);
     }
-    
+
     public void clearWhitelist() {
     	client.clearWhitelist();
     }
@@ -311,7 +316,7 @@ public class ProxyServer {
     public void setCaptureContent(boolean captureContent) {
         client.setCaptureContent(captureContent);
     }
-    
+
     public void setCaptureBinaryContent(boolean captureBinaryContent) {
         client.setCaptureBinaryContent(captureBinaryContent);
     }
@@ -348,7 +353,7 @@ public class ProxyServer {
                         lastCompleted = end;
                     }
                 }
-                
+
                 return lastCompleted != null && System.currentTimeMillis() - lastCompleted.getTime() >= quietPeriodInMs;
             }
         }, TimeUnit.MILLISECONDS, timeoutInMs);


### PR DESCRIPTION
Hi Patrick,

After some exploration I found it's not very difficult to incorporate the change to filter /proxy/:port/har results by pageRefs, so I prototyped an implementation. I can't really imagine how this would benefit for usual browser testing scenarios but I'm sure this is critical for long-running applications as I described in the mailing list.

I'm a newbie to Maven, so I may make dumb mistakes, but I confirmed this works as long as I checked in this way:

mvn compile
mvn exec:java &
curl -X POST -d "port=9091" http://127.0.0.1:8080/proxy
curl -X PUT -d 'captureContent=true&initialPageRef=1' http://127.0.0.1:8080/proxy/9091/har
  # Make some request using 127.0.0.1:9091...
curl -X PUT -d 'pageRef=2' http://127.0.0.1:8080/proxy/9091/har/pageRef
  # Make some request using 127.0.0.1:9091...
curl -X GET http://127.0.0.1:8080/proxy/9091/har  # This should show both page 1 and 2
curl -X GET http://127.0.0.1:8080/proxy/9091/har?pageRef=1  # This should show only page 1
  # ...
mvn -Prelease install -DskipTests=true

I skipped tests when installing because some tests hanged or failed. (Also saw this when `mvn test`.)

If you think this change is good, could you review this and let me know your thoughts? Also, I have another change for deleting existing pages, which I'll send a pull request shortly.

Thank you,
Hiroaki