### PR TITLE
Support a new API deletePages() to delete existing pages, with REST API support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ Once that is done, a new proxy will be available on the port returned. All you h
  - PUT /proxy/[port]/har/pageRef - starts a new page on the existing HAR. Supports the following parameters:
   - pageRef - the string name of the first page ref that should be used in the HAR. Defaults to "Page N" where N is the next page number.
  - DELETE /proxy/[port] - shuts down the proxy and closes the port
- - GET /proxy/[port]/har - returns the JSON/HAR content representing all the HTTP traffic passed through the proxy
+ - GET /proxy/[port]/har - returns the JSON/HAR content representing all the HTTP traffic passed through the proxy. Supports the following parameters:
+  - pageRef - a comma separated list of pageRefs to retrieve. If omitted all the pageRefs will be returned.
  - PUT /proxy/[port]/whitelist - Sets a list of URL patterns to whitelist. Takes the following parameters:
   - regex - a comma separated list of regular expressions
   - status - the HTTP status code to return for URLs that do not match the whitelist
- - DELETE /proxy/[port]/whitelist - Clears all URL patterns from the whitelist 
+ - DELETE /proxy/[port]/whitelist - Clears all URL patterns from the whitelist
  - PUT /proxy/[port]/blacklist - Set a URL to blacklist. Takes the following parameters:
   - regex - the blacklist regular expression
   - status - the HTTP status code to return for URLs that are blacklisted
@@ -76,7 +77,7 @@ Once that is done, a new proxy will be available on the port returned. All you h
   - Payload data should be json encoded username and password name/value pairs (ex: {"username": "myUsername", "password": "myPassword"}
  - PUT /proxy/[port]/wait - wait till all request are being made
   - quietPeriodInMs - Sets quiet period in milliseconds
-  - timeoutInMs - Sets timeout in milliseconds 
+  - timeoutInMs - Sets timeout in milliseconds
  - PUT /proxy/[port]/timeout - Handles different proxy timeouts. Takes the following parameters:
   - requestTimeout - request timeout in milliseconds. A timeout value of -1 is interpreted as infinite timeout. It equals -1 by default.
   - readTimeout - read timeout in milliseconds. Which is the timeout for waiting for data or, put differently, a maximum period inactivity between two consecutive data packets). A timeout value of zero is interpreted as an infinite timeout. It equals 60000 by default

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Once that is done, a new proxy will be available on the port returned. All you h
   - captureBinaryContent - Boolean, capture binary content
  - PUT /proxy/[port]/har/pageRef - starts a new page on the existing HAR. Supports the following parameters:
   - pageRef - the string name of the first page ref that should be used in the HAR. Defaults to "Page N" where N is the next page number.
+ - DELETE /proxy/[port]/har/pageRef/[pageRef] - deletes existing pages identified by [pageRef]. [pageRef] can take a form of a comma separated list. The current page cannot be deleted.
  - DELETE /proxy/[port] - shuts down the proxy and closes the port
  - GET /proxy/[port]/har - returns the JSON/HAR content representing all the HTTP traffic passed through the proxy. Supports the following parameters:
   - pageRef - a comma separated list of pageRefs to retrieve. If omitted all the pageRefs will be returned.
@@ -102,6 +103,14 @@ Now when traffic goes through port 9091 it will be attached to a page reference 
 That will ensure no more HTTP requests get attached to the old pageRef (Foo) and start getting attached to the new pageRef (Bar). You can also get the HAR content at any time like so:
 
     [~]$ curl http://localhost:8080/proxy/9091/har
+
+If you are interested only in the page Bar, you could query
+
+    [~]$ curl http://localhost:8080/proxy/9091/har?pageRef=Bar
+
+Or even you could delete the page Foo:
+
+    [~]$ curl -X DELETE http://localhost:8080/proxy/9091/har/pageRef/Foo
 
 Sometimes you will want to route requests through an upstream proxy server. In this case specify your proxy server by adding the httpProxy parameter to your create proxy request:
 

--- a/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHar.java
+++ b/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHar.java
@@ -1,0 +1,9 @@
+package net.lightbody.bmp.core.har;
+
+import java.util.Set;
+
+public class PageRefFilteredHar extends Har {
+    public PageRefFilteredHar(Har har, Set<String> pageRef) {
+        super(new PageRefFilteredHarLog(har.getLog(), pageRef));
+    }
+}

--- a/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHarLog.java
+++ b/src/main/java/net/lightbody/bmp/core/har/PageRefFilteredHarLog.java
@@ -1,0 +1,39 @@
+package net.lightbody.bmp.core.har;
+
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+public class PageRefFilteredHarLog extends HarLog {
+    public PageRefFilteredHarLog(HarLog log, Set<String> pageRef) {
+        super(log.getCreator());
+        setVersion(log.getVersion());
+        setBrowser(log.getBrowser());
+        setPages(getFilteredPages(log.getPages(), pageRef));
+        setEntries(getFilteredEntries(log.getEntries(), pageRef));
+        setComment(log.getComment());
+    }
+
+    private static List<HarPage> getFilteredPages(List<HarPage> pages, Set<String> pageRef) {
+        List<HarPage> filteredPages = new CopyOnWriteArrayList<HarPage>();
+        for (HarPage page : pages) {
+            if (pageRef.contains(page.getId())) {
+                filteredPages.add(page);
+            }
+        }
+        return filteredPages;
+    }
+
+    private static List<HarEntry> getFilteredEntries(List<HarEntry> entries, Set<String> pageRef) {
+        List<HarEntry> filteredEntries = new CopyOnWriteArrayList<HarEntry>();
+        for (HarEntry entry : entries) {
+            if (pageRef.contains(entry.getPageref())) {
+                filteredEntries.add(entry);
+            }
+        }
+        return filteredEntries;
+    }
+}

--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -24,6 +24,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -109,10 +110,10 @@ public class ProxyServer {
 
     /**
      * Get the the InetAddress that the Proxy server binds to when it starts.
-     * 
+     *
      * If not otherwise set via {@link #setLocalHost(InetAddress)}, defaults to
      * 0.0.0.0 (i.e. bind to any interface).
-     * 
+     *
      * Note - just because we bound to the address, doesn't mean that it can be
      * reached. E.g. trying to connect to 0.0.0.0 is going to fail. Use
      * {@link #getConnectableLocalHost()} if you're looking for a host that can be
@@ -124,16 +125,16 @@ public class ProxyServer {
         }
         return localHost;
     }
-    
+
     /**
      * Return a plausible {@link InetAddress} that other processes can use to
      * contact the proxy.
-     * 
+     *
      * In essence, this is the same as {@link #getLocalHost()}, but avoids
      * returning 0.0.0.0. as no-one can connect to that. If no other host has
      * been set via {@link #setLocalHost(InetAddress)}, will return
      * {@link InetAddress#getLocalHost()}
-     * 
+     *
      * No attempt is made to check the address for reachability before it is
      * returned.
      */
@@ -173,6 +174,10 @@ public class ProxyServer {
         }
 
         return client.getHar();
+    }
+
+    public Har getHar(Set<String> pageRef) {
+        return new PageRefFilteredHar(getHar(), pageRef);
     }
 
     public Har newHar(String initialPageRef) {
@@ -279,7 +284,7 @@ public class ProxyServer {
     public void rewriteUrl(String match, String replace) {
         client.rewriteUrl(match, replace);
     }
-    
+
     public void clearRewriteRules() {
     	client.clearRewriteRules();
     }
@@ -287,7 +292,7 @@ public class ProxyServer {
     public void blacklistRequests(String pattern, int responseCode) {
         client.blacklistRequests(pattern, responseCode);
     }
-    
+
     public void clearBlacklist() {
     	client.clearBlacklist();
     }
@@ -295,7 +300,7 @@ public class ProxyServer {
     public void whitelistRequests(String[] patterns, int responseCode) {
         client.whitelistRequests(patterns, responseCode);
     }
-    
+
     public void clearWhitelist() {
     	client.clearWhitelist();
     }
@@ -311,7 +316,7 @@ public class ProxyServer {
     public void setCaptureContent(boolean captureContent) {
         client.setCaptureContent(captureContent);
     }
-    
+
     public void setCaptureBinaryContent(boolean captureBinaryContent) {
         client.setCaptureBinaryContent(captureBinaryContent);
     }
@@ -348,7 +353,7 @@ public class ProxyServer {
                         lastCompleted = end;
                     }
                 }
-                
+
                 return lastCompleted != null && System.currentTimeMillis() - lastCompleted.getTime() >= quietPeriodInMs;
             }
         }, TimeUnit.MILLISECONDS, timeoutInMs);

--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -23,6 +23,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -212,6 +213,20 @@ public class ProxyServer {
         currentPage.getPageTimings().setOnLoad(new Date().getTime() - currentPage.getStartedDateTime().getTime());
         client.setHarPageRef(null);
         currentPage = null;
+    }
+
+    public void deletePages(Set<String> pageRef) {
+        pageRef.remove(currentPage.getId());
+
+        // Delete the given set of pages by preserving the rest of existing pages.
+        Set<String> filteredPages = new HashSet<String>();
+        Har har = getHar();
+        for (HarPage page : har.getLog().getPages()) {
+            if (!pageRef.contains(page.getId())) {
+                filteredPages.add(page.getId());
+            }
+        }
+        har.setLog(new PageRefFilteredHarLog(har.getLog(), filteredPages));
     }
 
     public void setRetryCount(int count) {

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -134,6 +134,20 @@ public class ProxyResource {
         return Reply.saying().ok();
     }
 
+    @Delete
+    @At("/:port/har/pageRef/:pageRef")
+    public Reply<?> deletePages(@Named("port") int port, @Named("pageRef") String pageRef) {
+        ProxyServer proxy = proxyManager.get(port);
+        if (proxy == null) {
+            return Reply.saying().notFound();
+        }
+
+        // NOTE: Query parameters can't be used with DELETE method.
+        proxy.deletePages(new HashSet<String>(Arrays.asList(pageRef.split(","))));
+
+        return Reply.saying().ok();
+    }
+
     @Put
     @At("/:port/blacklist")
     public Reply<?> blacklist(@Named("port") int port, Request request) {


### PR DESCRIPTION
Hi Patrick,

Here is another pull request I mentioned in the last one. This request contains the last commit ef937b4, so if you are going to review see 4c1807d for the real diff. (Or if more preferred, I would recreate this request after the last request has resolved.)

This change adds an ability to delete existing (possibly old) pages. This should help to reduce the memory usage of browsermob-proxy, without creating service down time (unlike DELETE /proxy/:port/). Probably no-op for usual testing scenarios, but I think this is especially useful for long-running applications.

Possible scenario for a long-running, incremental consumer: 1) create a new page n+1, 2) get and process a HAR in page n, 3) delete page n, 4) n=n+1 and go back to step 1.

If you think this change is good, could you please take a look at the code?

Thank you,
Hiroaki