### PR TITLE
Update Apache HttpClient to 4.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.3</version>
+            <version>4.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Closes #73. With this patch, `mvn -P release -Dmaven.test.skip=true` downloads the bug-free version of HttpClient to target/appassembler/lib and uses it correctly in target/appassembler/bin/browsermob-proxy.
