### PR TITLE
fixed Base64 conflict in Java8

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -4,6 +4,7 @@ import net.lightbody.bmp.core.har.*;
 import net.lightbody.bmp.proxy.BlacklistEntry;
 import net.lightbody.bmp.proxy.WhitelistEntry;
 import net.lightbody.bmp.proxy.util.*;
+import net.lightbody.bmp.proxy.util.Base64;
 import net.sf.uadetector.ReadableUserAgent;
 import net.sf.uadetector.UserAgentStringParser;
 import net.sf.uadetector.service.UADetectorServiceFactory;


### PR DESCRIPTION
made an explicit import for `net.lightbody.bmp.proxy.util.Base64` to resolve the conflict between `net.lightbody.bmp.proxy.util.Base64` and `java.util.Base64` in Java8
