### PR TITLE
blacklist with method matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Once that is done, a new proxy will be available on the port returned. All you h
  - PUT /proxy/[port]/blacklist - Set a URL to blacklist. Takes the following parameters:
   - regex - the blacklist regular expression
   - status - the HTTP status code to return for URLs that are blacklisted
+  - method - regular expression for matching method., e.g., POST. Emtpy for matching all method.
  - DELETE /proxy/[port]/blacklist - Clears all URL patterns from the blacklist
  - PUT /proxy/[port]/limit - Limit the bandwidth through the proxy. Takes the following parameters:
   - downstreamKbps - Sets the downstream kbps

--- a/src/main/java/net/lightbody/bmp/proxy/BlacklistEntry.java
+++ b/src/main/java/net/lightbody/bmp/proxy/BlacklistEntry.java
@@ -6,10 +6,12 @@ public class BlacklistEntry
 {
     private Pattern pattern;
     private int responseCode;
+	private Pattern method;
 
-    public BlacklistEntry(String pattern, int responseCode) {
+    public BlacklistEntry(String pattern, int responseCode, String method) {
         this.pattern = Pattern.compile(pattern);
         this.responseCode = responseCode;
+		this.method = Pattern.compile("".equals(method) ? ".*" : method);
     }
 
     public Pattern getPattern() {
@@ -19,4 +21,8 @@ public class BlacklistEntry
     public int getResponseCode() {
         return this.responseCode;
     }
+	
+	public Pattern getMethod() {
+		return this.method;
+	}
 }

--- a/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -333,8 +333,8 @@ public class ProxyServer {
     	client.clearRewriteRules();
     }
 
-    public void blacklistRequests(String pattern, int responseCode) {
-        client.blacklistRequests(pattern, responseCode);
+    public void blacklistRequests(String pattern, int responseCode, String method) {
+        client.blacklistRequests(pattern, responseCode, method);
     }
 
     public List<BlacklistEntry> getBlacklistedRequests() {

--- a/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -172,7 +172,8 @@ public class ProxyResource {
 
         String blacklist = request.param("regex");
         int responseCode = parseResponseCode(request.param("status"));
-        proxy.blacklistRequests(blacklist, responseCode);
+		String method = request.param("method");
+        proxy.blacklistRequests(blacklist, responseCode, method);
 
         return Reply.saying().ok();
     }

--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -676,7 +676,8 @@ public class BrowserMobHttpClient {
 
         if (blacklistEntries != null) {
             for (BlacklistEntry blacklistEntry : blacklistEntries) {
-                if (blacklistEntry.getPattern().matcher(url).matches()) {
+                if (blacklistEntry.getPattern().matcher(url).matches()
+					&& blacklistEntry.getMethod().matcher(method.getMethod()).matches()) {
                     mockResponseCode = blacklistEntry.getResponseCode();
                     break;
                 }
@@ -1196,12 +1197,12 @@ public class BrowserMobHttpClient {
 
     // this method is provided for backwards compatibility before we renamed it to
     // blacklistRequests (note the plural)
-    public void blacklistRequest(String pattern, int responseCode) {
-        blacklistRequests(pattern, responseCode);
+    public void blacklistRequest(String pattern, int responseCode, String method) {
+        blacklistRequests(pattern, responseCode, method);
     }
 
-    public void blacklistRequests(String pattern, int responseCode) {
-        blacklistEntries.add(new BlacklistEntry(pattern, responseCode));
+    public void blacklistRequests(String pattern, int responseCode, String method) {
+        blacklistEntries.add(new BlacklistEntry(pattern, responseCode, method));
     }
 
     public List<BlacklistEntry> getBlacklistedRequests() {


### PR DESCRIPTION
Added new parameter 'method' for blacklisting. Useful in simulating 500 on CORS APIs, where OPTIONS should not be blacklisted. e.g., 
curl -X PUT http://localhost:8080/proxy/[:port]/blacklist -d "regex=.*&status=500&method=POST"
