### PR TITLE
Updated to latest uadetector-resources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>net.sf.uadetector</groupId>
             <artifactId>uadetector-resources</artifactId>
-            <version>2014.09</version>
+            <version>2014.10</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>


### PR DESCRIPTION
Since user-agent-string.info is down, this will provide the latest compiled-in user agent string definitions.

Updated to latest uadetector-resources. 
Added HAR browser name/version test.
