### PR TITLE
Fix for uadetector unkown user agent

### DIFF
--- a/src/main/java/net/lightbody/bmp/proxy/guice/ConfigModule.java
+++ b/src/main/java/net/lightbody/bmp/proxy/guice/ConfigModule.java
@@ -9,7 +9,6 @@ import java.util.List;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
-import net.sf.uadetector.service.UADetectorServiceFactory;
 
 public class ConfigModule implements Module {
     private String[] args;
@@ -89,6 +88,7 @@ public class ConfigModule implements Module {
         /*
          * Init User Agent String Parser, update of the UAS datastore will run in background.
          */
-        UADetectorServiceFactory.getCachingAndUpdatingParser();
+        // temporarily disabled because user-agent-string.info no longer exists
+        //BrowserMobHttpClient.getUserAgentStringParser();
     }
 }

--- a/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -1491,7 +1491,9 @@ public class BrowserMobHttpClient {
 		if (parser == null) {
 			synchronized (PARSER_INIT_LOCK) {
 				if (parser == null) {
-					parser = UADetectorServiceFactory.getCachingAndUpdatingParser();
+                    // using resourceModuleParser for now because user-agent-string.info no longer exists. the updating
+                    // parser will get incorrect data and wipe out its entire user agent repository.
+					parser = UADetectorServiceFactory.getResourceModuleParser();
 				}
 			}
 		}

--- a/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
+++ b/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
@@ -392,7 +392,7 @@ public class MailingListIssuesTest extends DummyServerTest {
     
             // show that we can capture the HTML of the root page
             String text = har.getLog().getEntries().get(0).getResponse().getContent().getText();
-            Assert.assertTrue(text.contains("<title>\r\n\tWhat's My User Agent?\r\n</title>"));
+            Assert.assertTrue(text.contains("My User Agent?"));
         } finally {
             server.stop();
             if (driver != null) {


### PR DESCRIPTION
I noticed the uadetector library is no longer working properly because user-agent-string.info is not returning user agent info. http://user-agent-string.info redirects to http://udger.com/, so when uadetector tries to read updated user agent strings, it gets an invalid response which clears uadetector's saved cache of user agents.

Until uadetector is updated to pull user agent strings from somewhere else, I've changed the way uadetector is initialized so it only reads user agent strings from the saved resources.