### PR TITLE
Minor cleanup of javadoc warnings

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarEntry.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarEntry.java
@@ -55,7 +55,7 @@ public class HarEntry {
      entry.timings.connect + entry.timings.send + entry.timings.wait +
      entry.timings.receive;
      </pre>
-     * @return
+     * @return time for this HAR entry
      */
     public long getTime() {
         HarTimings timings = getTimings();

--- a/browsermob-core/src/main/java/net/lightbody/bmp/core/json/ISO8601WithTDZDateFormatter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/core/json/ISO8601WithTDZDateFormatter.java
@@ -14,7 +14,7 @@ import java.util.Date;
  * 
  * @author Damien Jubeau <damien.jubeau@dareboost.com>
  * Allows Date Format to be compliant with Har 1.2 Spec : ISO 8601 with Time Zone Designator
- * @see https://github.com/lightbody/browsermob-proxy/issues/44
+ * @see <a href="https://github.com/lightbody/browsermob-proxy/issues/44">https://github.com/lightbody/browsermob-proxy/issues/44</a>
  *
  */
 public class ISO8601WithTDZDateFormatter extends JsonSerializer<Date> {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/util/Base64.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/util/Base64.java
@@ -85,7 +85,7 @@ public class Base64 {
     /**
      * Translates the specified Base64 string (as per Preferences.get(byte[])) into a byte array.
      *
-     * @throw IllegalArgumentException if <tt>s</tt> is not a valid Base64 string.
+     * @throws IllegalArgumentException if <tt>s</tt> is not a valid Base64 string.
      */
     public static byte[] base64ToByteArray(String s) {
         return base64ToByteArray(s, false);
@@ -94,7 +94,7 @@ public class Base64 {
     /**
      * Translates the specified "alternate representation" Base64 string into a byte array.
      *
-     * @throw IllegalArgumentException or ArrayOutOfBoundsException if <tt>s</tt> is not a valid alternate
+     * @throws IllegalArgumentException or ArrayOutOfBoundsException if <tt>s</tt> is not a valid alternate
      * representation Base64 string.
      */
     public static byte[] altBase64ToByteArray(String s) {
@@ -152,7 +152,7 @@ public class Base64 {
      * Translates the specified character, which is assumed to be in the "Base 64 Alphabet" into its equivalent 6-bit
      * positive integer.
      *
-     * @throw IllegalArgumentException or ArrayOutOfBoundsException if c is not in the Base64 Alphabet.
+     * @throws IllegalArgumentException or ArrayOutOfBoundsException if c is not in the Base64 Alphabet.
      */
     private static int base64toInt(char c, byte[] alphaToInt) {
         int result = alphaToInt[c];


### PR DESCRIPTION
Reduces a few of the many javadoc warnings that appear when building. PR #157 will reduce a few more, but most of the remaining will have to wait until after Jetty 5 is retired.