### PR TITLE
Added seldom-used HTTP TRACE support

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/BrowserMobProxyHandler.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/BrowserMobProxyHandler.java
@@ -207,7 +207,9 @@ public class BrowserMobProxyHandler extends SeleniumProxyHandler {
             } else if ("HEAD".equals(request.getMethod())) {
                 httpReq = httpClient.newHead(urlStr, request);
             } else if ("PATCH".equals(request.getMethod())) {
-            	httpReq = httpClient.newPatch(urlStr, request);
+                httpReq = httpClient.newPatch(urlStr, request);
+            } else if ("TRACE".equals(request.getMethod())) {
+                httpReq = httpClient.newTrace(urlStr, request);
             } else {
                 LOG.warn("Unexpected request method {}, giving up", request.getMethod());
                 request.setHandled(true);

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -72,6 +72,7 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.config.Registry;
@@ -503,6 +504,15 @@ public class BrowserMobHttpClient {
             return new BrowserMobHttpRequest(new HttpHead(uri), this, -1, captureContent, proxyRequest);
         } catch (URISyntaxException e) {
             throw reportBadURI(url, "HEAD", e);
+        }
+    }
+
+    public BrowserMobHttpRequest newTrace(String url, net.lightbody.bmp.proxy.jetty.http.HttpRequest proxyRequest) {
+        try {
+            URI uri = makeUri(url);
+            return new BrowserMobHttpRequest(new HttpTrace(uri), this, -1, captureContent, proxyRequest);
+        } catch (URISyntaxException e) {
+            throw reportBadURI(url, "TRACE", e);
         }
     }
 


### PR DESCRIPTION
Although seldom-used, TRACE is a valid HTTP method.