### PR TITLE
Threading cleanup

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/core/util/ThreadUtils.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/core/util/ThreadUtils.java
@@ -1,93 +1,99 @@
 package net.lightbody.bmp.core.util;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadInfo;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 public class ThreadUtils {
-    public static String dumpAllThreads() {
-        ThreadInfo[] dumps = ManagementFactory.getThreadMXBean().dumpAllThreads(true, true);
-        StringBuilder out = new StringBuilder("Thread Dump\n");
-        for (ThreadInfo dump : dumps) {
-            out.append("-------------------------\n").append(dump);
-        }
-
-        return out.toString();
-    }
-
+    /**
+     * Functional interface to specify a condition to wait for. The checkCondition() method should take a minimal amount of time to execute.
+     */
     public static interface WaitCondition {
-        public boolean checkCondition(long elapsedTimeInMs);
+        public boolean checkCondition();
     }
 
-    public static void sleep(TimeUnit timeUnit, long duration) {
+    private static final int DEFAULT_POLL_INTERVAL_MS = 500;
+
+    // use a  single threaded executor to poll for all conditions -- WaitConditions should be very fast!
+    private static final ScheduledExecutorService waitConditionPollingExecutor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = Executors.defaultThreadFactory().newThread(r);
+            thread.setName("wait-condition-polling-thread");
+            thread.setDaemon(true);
+            return thread;
+        }
+    });
+
+    /**
+     * Waits for the specified condition to be true. The condition will be evaluated when the method is invoked, and then <i>may be</i> polled
+     * periodically, until the condition returns true or the specified timeout has elapsed. If the condition is not true after the timeout
+     * has elapsed, it is guaranteed to be evaluated at least once more before the method returns.
+     *
+     * @param condition condition to wait on
+     * @param timeout time to wait for condition to be true
+     * @param timeUnit unit of time to wait
+     * @return true if the condition was satisfied within the specified time, otherwise false
+     */
+    public static boolean pollForCondition(WaitCondition condition, long timeout, TimeUnit timeUnit) {
+        return pollForCondition(condition, timeout, timeUnit, DEFAULT_POLL_INTERVAL_MS);
+    }
+
+    /**
+     * Waits for the specified condition to be true. The condition will be evaluated when the method is invoked, and then <i>may be</i> polled
+     * periodically, until the condition returns true or the specified timeout has elapsed. If the condition is not true after the timeout
+     * has elapsed, it is guaranteed to be evaluated at least once more before the method returns.
+     *
+     * @param condition condition to wait on
+     * @param timeout time to wait for condition to be true
+     * @param timeUnit unit of time to wait
+     * @param pollIntervalMs interval at which to poll, in milliseconds
+     * @return true if the condition was satisfied within the specified time, otherwise false
+     */
+    public static boolean pollForCondition(WaitCondition condition, final long timeout, final TimeUnit timeUnit, long pollIntervalMs) {
+        if (condition.checkCondition()) {
+            return true;
+        }
+
+        // wrap the WaitCondition in a WeakReference, just to make sure it hasn't been orphaned
+        final WeakReference<WaitCondition> conditionWrapper = new WeakReference<WaitCondition>(condition);
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        ScheduledFuture<?> pollingTask = waitConditionPollingExecutor.scheduleWithFixedDelay(new Runnable() {
+            private final long taskStart = System.currentTimeMillis();
+
+            @Override
+            public void run() {
+                WaitCondition condition = conditionWrapper.get();
+                if (condition == null || (System.currentTimeMillis() - taskStart > TimeUnit.MILLISECONDS.convert(timeout, timeUnit))) {
+                    // max time limit elapsed or condition was garbage collected, so throw an exception to prevent this task from being rescheduled again
+                    throw new RuntimeException("Stopped polling for condition because time limit elapsed or condition was garbage collected");
+                }
+
+                if (condition.checkCondition()) {
+                    latch.countDown();
+                }
+            }
+        }, pollIntervalMs, pollIntervalMs, TimeUnit.MILLISECONDS);
+
         try {
-            timeUnit.sleep(duration);
-        }
-        catch (InterruptedException ex) {
+            boolean conditionMet = latch.await(timeout, timeUnit);
+
+            if (conditionMet || condition.checkCondition()) {
+                return true;
+            } else {
+                return false;
+            }
+        } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            return false;
+        } finally {
+            // cancel the polling task so it is not executed anymore
+            pollingTask.cancel(true);
         }
-    }
-
-    public static boolean waitFor(WaitCondition condition) {
-        boolean result = false;
-        if (condition != null) {
-            long startTime = System.currentTimeMillis();
-
-            while (!(result = condition.checkCondition(System.currentTimeMillis() - startTime))) {
-                try {
-                    Thread.sleep(100);
-                }
-                catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        }
-
-        return result;
-    }
-
-    public static boolean waitFor(WaitCondition condition, TimeUnit timeUnit, long timeoutDuration) {
-        long timeout = timeUnit.toMillis(timeoutDuration);
-
-        boolean result = false;
-        if (condition != null) {
-            long startTime = System.currentTimeMillis();
-            long curTime = startTime;
-
-            while (!(result = condition.checkCondition(curTime - startTime)) && (curTime - startTime < timeout)) {
-                try {
-                    Thread.sleep(100);
-                }
-                catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                }
-                curTime = System.currentTimeMillis();
-            }
-        }
-
-        return result;
-    }
-
-    public static boolean waitFor(WaitCondition condition, TimeUnit timeUnitTimeout, long timeoutDuration, TimeUnit timeUnitSleep, long sleepDuration) {
-        long timeout = timeUnitTimeout.toMillis(timeoutDuration);
-        long sleepBetween = timeUnitSleep.toMillis(sleepDuration);
-
-        boolean result = false;
-        if (condition != null) {
-            long startTime = System.currentTimeMillis();
-            long curTime = startTime;
-
-            while (!(result = condition.checkCondition(curTime - startTime)) && (curTime - startTime < timeout)) {
-                try {
-                    Thread.sleep(sleepBetween);
-                }
-                catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                }
-                curTime = System.currentTimeMillis();
-            }
-        }
-
-        return result;
     }
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -1129,7 +1129,6 @@ public class BrowserMobHttpClient {
         blacklistEntries.clear();
         credsProvider.clear();
         httpClientConnMgr.shutdown();
-        HttpClientInterrupter.release(this);
     }
 
     public void abortActiveRequests() {
@@ -1442,6 +1441,10 @@ public class BrowserMobHttpClient {
 
     private enum AuthType {
         NONE, BASIC, NTLM
+    }
+
+    public boolean isShutdown() {
+        return shutdown;
     }
 
     public void clearDNSCache() {

--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/MailingListIssuesTest.java
@@ -107,12 +107,12 @@ public class MailingListIssuesTest extends LocalServerTest {
 
         String body = IOUtils.toStringAndClose(client.execute(new HttpGet(getLocalServerHostnameAndPort() + "/a.txt")).getEntity().getContent());
 
-        ThreadUtils.waitFor(new ThreadUtils.WaitCondition() {
+        ThreadUtils.pollForCondition(new ThreadUtils.WaitCondition() {
             @Override
-            public boolean checkCondition(long elapsedTimeInMs) {
+            public boolean checkCondition() {
                 return interceptedBody[0] != null;
             }
-        }, TimeUnit.SECONDS, 10);
+        }, 10, TimeUnit.SECONDS);
 
         Assert.assertEquals(interceptedBody[0], body);
     }


### PR DESCRIPTION
Modified the BrowserMobHttpClient timeout polling mechanism and the waitForNetworkTrafficToStop polling mechanisms to use ScheduledExecutorServices with a single thread.