### PR TITLE
HTTP 504 on connection timeout

### DIFF
--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/ErrorResponseTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/ErrorResponseTest.java
@@ -45,7 +45,7 @@ public class ErrorResponseTest extends ProxyServerTest {
     }
 
     @Test
-    public void testHostUnreachable() throws IOException {
+    public void testConnectionTimeout() throws IOException {
         proxy.setConnectionTimeout(1);
 
         String url = "http://1.2.3.4";

--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/ErrorResponseTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/ErrorResponseTest.java
@@ -51,7 +51,7 @@ public class ErrorResponseTest extends ProxyServerTest {
         String url = "http://1.2.3.4";
 
         try (CloseableHttpResponse response = getResponseFromHost(url)) {
-            assertEquals("Expected 502 error due to connection timeout", 502, response.getStatusLine().getStatusCode());
+            assertEquals("Expected 504 error due to connection timeout", 504, response.getStatusLine().getStatusCode());
 
             String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
 


### PR DESCRIPTION
Returning HTTP 504 Gateway Timeout when the connection to the remote server times out. 504 better matches the HTTP status code definition:
`The server, while acting as a gateway or proxy, did not receive a timely response from the upstream server specified by the URI (e.g. HTTP, FTP, LDAP) or some other auxiliary server (e.g. DNS) it needed to access in attempting to complete the request.`
Than 502:
`The server, while acting as a gateway or proxy, received an invalid response from the upstream server it accessed in attempting to fulfill the request.`