### PR TITLE
Move user agent parser to utility class

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -119,8 +119,6 @@ public class BrowserMobHttpClient {
 
 	private static final Logger LOG = LoggerFactory.getLogger(BrowserMobHttpClient.class);
 	
-	private static volatile UserAgentStringParser parser;
-	
     private static final int BUFFER = 4096;
 
     private volatile Har har;
@@ -630,7 +628,7 @@ public class BrowserMobHttpClient {
                 String userAgent = uaHeaders[0].getValue();
                 try {
                     // note: this doesn't work for 'Fandango/4.5.1 CFNetwork/548.1.4 Darwin/11.0.0'
-                    ReadableUserAgent uai = getUserAgentStringParser().parse(userAgent);
+                    ReadableUserAgent uai = BrowserMobProxyUtil.getUserAgentStringParser().parse(userAgent);
                     String browser = uai.getName();
                     String version = uai.getVersionNumber().toVersionString();
                     har.getLog().setBrowser(new HarNameVersion(browser, version));
@@ -1144,7 +1142,7 @@ public class BrowserMobHttpClient {
         this.har = har;
         
         // eagerly initialize the User Agent String Parser, since it will be needed for the HAR
-        getUserAgentStringParser();
+        BrowserMobProxyUtil.getUserAgentStringParser();
     }
 
     public void setHarPageRef(String harPageRef) {
@@ -1490,24 +1488,5 @@ public class BrowserMobHttpClient {
 
         return bytesCopied;
     }
-    
-    private static final Object PARSER_INIT_LOCK = new Object();
-    
-    /**
-     * Retrieve the User Agent String Parser. Create the parser if it has not yet been initialized.
-     * @return
-     */
-    public static UserAgentStringParser getUserAgentStringParser() {
-		if (parser == null) {
-			synchronized (PARSER_INIT_LOCK) {
-				if (parser == null) {
-                    // using resourceModuleParser for now because user-agent-string.info no longer exists. the updating
-                    // parser will get incorrect data and wipe out its entire user agent repository.
-					parser = UADetectorServiceFactory.getResourceModuleParser();
-				}
-			}
-		}
-		
-		return parser;
-	}
+
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/util/BrowserMobProxyUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/util/BrowserMobProxyUtil.java
@@ -16,7 +16,8 @@ public class BrowserMobProxyUtil {
 
     /**
      * Retrieve the User Agent String Parser. Create the parser if it has not yet been initialized.
-     * @return
+     * 
+     * @return singleton UserAgentStringParser object
      */
     public static UserAgentStringParser getUserAgentStringParser() {
         if (parser == null) {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/util/BrowserMobProxyUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/util/BrowserMobProxyUtil.java
@@ -1,0 +1,35 @@
+package net.lightbody.bmp.proxy.util;
+
+import net.sf.uadetector.UserAgentStringParser;
+import net.sf.uadetector.service.UADetectorServiceFactory;
+
+/**
+ * General utility class for functionality and classes used mostly internally by BrowserMob Proxy.
+ */
+public class BrowserMobProxyUtil {
+    /**
+     * Singleton User Agent parser.
+     */
+    private static volatile UserAgentStringParser parser;
+
+    private static final Object PARSER_INIT_LOCK = new Object();
+
+    /**
+     * Retrieve the User Agent String Parser. Create the parser if it has not yet been initialized.
+     * @return
+     */
+    public static UserAgentStringParser getUserAgentStringParser() {
+        if (parser == null) {
+            synchronized (PARSER_INIT_LOCK) {
+                if (parser == null) {
+                    // using resourceModuleParser for now because user-agent-string.info no longer exists. the updating
+                    // parser will get incorrect data and wipe out its entire user agent repository.
+                    parser = UADetectorServiceFactory.getResourceModuleParser();
+                }
+            }
+        }
+
+        return parser;
+    }
+
+}


### PR DESCRIPTION
Part of a code cleanup effort to move non-proxy-related functionality out of the ProxyServer class.