### PR TITLE
LegacyProxyServer interface

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/LegacyProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/LegacyProxyServer.java
@@ -1,0 +1,139 @@
+package net.lightbody.bmp.proxy;
+
+import net.lightbody.bmp.core.har.Har;
+import net.lightbody.bmp.exception.NameResolutionException;
+import net.lightbody.bmp.proxy.http.RequestInterceptor;
+import net.lightbody.bmp.proxy.http.ResponseInterceptor;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponseInterceptor;
+import org.java_bandwidthlimiter.StreamManager;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Describes the legacy BrowserMob Proxy 2.0 interface. Clients <b>should not</b> implement or use this interface.
+ *
+ * Use {@link net.lightbody.bmp.BrowserMobProxy}.
+ */
+public interface LegacyProxyServer {
+    void start();
+
+    org.openqa.selenium.Proxy seleniumProxy() throws NameResolutionException;
+
+    void cleanup();
+
+    void stop();
+
+    void abort();
+
+    int getPort();
+
+    void setPort(int port);
+
+    InetAddress getLocalHost();
+
+    InetAddress getConnectableLocalHost() throws UnknownHostException;
+
+    void setLocalHost(InetAddress localHost);
+
+    Har getHar();
+
+    Har newHar(String initialPageRef);
+
+    Har newHar(String initialPageRef, String initialPageTitle);
+
+    Har newPage(String pageRef);
+
+    Har newPage(String pageRef, String pageTitle);
+
+    void endPage();
+
+    void setRetryCount(int count);
+
+    void remapHost(String source, String target);
+
+    @Deprecated
+    void addRequestInterceptor(HttpRequestInterceptor i);
+
+    void addRequestInterceptor(RequestInterceptor interceptor);
+
+    @Deprecated
+    void addResponseInterceptor(HttpResponseInterceptor i);
+
+    void addResponseInterceptor(ResponseInterceptor interceptor);
+
+    StreamManager getStreamManager();
+
+    //use getStreamManager().setDownstreamKbps instead
+    @Deprecated
+    void setDownstreamKbps(long downstreamKbps);
+
+    //use getStreamManager().setUpstreamKbps instead
+    @Deprecated
+    void setUpstreamKbps(long upstreamKbps);
+
+    //use getStreamManager().setLatency instead
+    @Deprecated
+    void setLatency(long latency);
+
+    void setRequestTimeout(int requestTimeout);
+
+    void setSocketOperationTimeout(int readTimeout);
+
+    void setConnectionTimeout(int connectionTimeout);
+
+    void autoBasicAuthorization(String domain, String username, String password);
+
+    void rewriteUrl(String match, String replace);
+
+    void clearRewriteRules();
+
+    void blacklistRequests(String pattern, int responseCode);
+
+    void blacklistRequests(String pattern, int responseCode, String method);
+
+    @Deprecated
+    List<BlacklistEntry> getBlacklistedRequests();
+
+    Collection<BlacklistEntry> getBlacklistedUrls();
+
+    boolean isWhitelistEnabled();
+
+    @Deprecated
+    List<Pattern> getWhitelistRequests();
+
+    Collection<Pattern> getWhitelistPatterns();
+
+    Collection<String> getWhitelistUrls();
+
+    int getWhitelistResponseCode();
+
+    void clearBlacklist();
+
+    void whitelistRequests(String[] patterns, int responseCode);
+
+    void enableEmptyWhitelist(int responseCode);
+
+    void clearWhitelist();
+
+    void addHeader(String name, String value);
+
+    void setCaptureHeaders(boolean captureHeaders);
+
+    void setCaptureContent(boolean captureContent);
+
+    void setCaptureBinaryContent(boolean captureBinaryContent);
+
+    void clearDNSCache();
+
+    void setDNSCacheTimeout(int timeout);
+
+    void waitForNetworkTrafficToStop(long quietPeriodInMs, long timeoutInMs);
+
+    void setOptions(Map<String, String> options);
+}

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/LegacyProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/LegacyProxyServer.java
@@ -107,8 +107,6 @@ public interface LegacyProxyServer {
     @Deprecated
     List<Pattern> getWhitelistRequests();
 
-    Collection<Pattern> getWhitelistPatterns();
-
     Collection<String> getWhitelistUrls();
 
     int getWhitelistResponseCode();

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -4,6 +4,7 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -37,7 +38,7 @@ import org.openqa.selenium.Proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ProxyServer {
+public class ProxyServer implements LegacyProxyServer {
     private static final HarNameVersion CREATOR = new HarNameVersion("BrowserMob Proxy", "2.0");
     private static final Logger LOG = LoggerFactory.getLogger(ProxyServer.class);
 
@@ -138,6 +139,11 @@ public class ProxyServer {
 			// the try/catch block in server.stop() is manufacturing a phantom InterruptedException, so this should not occur 
 			throw new JettyException("Exception occurred when stopping the server", e);
 		}
+    }
+
+    @Override
+    public void abort() {
+        stop();
     }
 
     public int getPort() {
@@ -248,11 +254,11 @@ public class ProxyServer {
         return oldHar;
     }
 
-    public void newPage(String pageRef) {
-        newPage(pageRef, null);
+    public Har newPage(String pageRef) {
+        return newPage(pageRef, null);
     }
 
-    public void newPage(String pageRef, String pageTitle) {
+    public Har newPage(String pageRef, String pageTitle) {
         if (pageRef == null) {
             pageRef = "Page " + pageCount.get();
         }
@@ -266,6 +272,8 @@ public class ProxyServer {
         client.getHar().getLog().addPage(currentPage);
 
         pageCount.incrementAndGet();
+
+        return client.getHar();
     }
 
     public void endPage() {
@@ -385,9 +393,18 @@ public class ProxyServer {
 		return client.getWhitelistRequests();
 	}
 	
-	public Collection<Pattern> getWhitelistUrls() {
+	public Collection<Pattern> getWhitelistPatterns() {
 		return client.getWhitelistUrls();
 	}
+
+    public Collection<String> getWhitelistUrls() {
+        List<String> whitelistUrls = new ArrayList<String>(client.getWhitelistUrls().size());
+        for (Pattern pattern : client.getWhitelistUrls()) {
+            whitelistUrls.add(pattern.pattern());
+        }
+
+        return whitelistUrls;
+    }
 
 	public int getWhitelistResponseCode() {
 		return client.getWhitelistResponseCode();

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -393,10 +393,6 @@ public class ProxyServer implements LegacyProxyServer {
 		return client.getWhitelistRequests();
 	}
 	
-	public Collection<Pattern> getWhitelistPatterns() {
-		return client.getWhitelistUrls();
-	}
-
     public Collection<String> getWhitelistUrls() {
         List<String> whitelistUrls = new ArrayList<String>(client.getWhitelistUrls().size());
         for (Pattern pattern : client.getWhitelistUrls()) {


### PR DESCRIPTION
As a step before the merge of PR #162, this PR introduces a LegacyProxyServer interface that codifies the 2.0.0 interface. There is one potentially-breaking change that may affect client code: the getWhitelistUrls() method now returns `Collection<String>` instead of `Collection<Pattern>`. This will align the LegacyProxyServer interface with the new interface defined in #162.