### PR TITLE
Use LegacyProxyServer interface instead of ProxyServer implementation

### DIFF
--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/PhantomJSTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/PhantomJSTest.java
@@ -17,7 +17,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import static org.junit.Assume.assumeFalse;
 
 public class PhantomJSTest {
-    ProxyServer server;
+    private LegacyProxyServer server;
 
     @Before
     public void skipForTravisCi() {

--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/test/util/ProxyServerTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/test/util/ProxyServerTest.java
@@ -1,5 +1,6 @@
 package net.lightbody.bmp.proxy.test.util;
 
+import net.lightbody.bmp.proxy.LegacyProxyServer;
 import net.lightbody.bmp.proxy.ProxyServer;
 import net.lightbody.bmp.proxy.util.IOUtils;
 import org.apache.http.HttpHost;
@@ -34,7 +35,7 @@ public abstract class ProxyServerTest {
     /**
      * This test's proxy server, running on 127.0.0.1.
      */
-    protected ProxyServer proxy;
+    protected LegacyProxyServer proxy;
 
     /**
      * CloseableHttpClient that will connect through the local proxy running on 127.0.0.1.
@@ -60,7 +61,7 @@ public abstract class ProxyServerTest {
      * Hook to allow tests to initialize the proxy server with a custom configuration, but still leverage the rest of the
      * functionality in ProxyServerTest. The default implementation creates a new proxy server on port 0 (JVM-assigned port).
      */
-    protected ProxyServer createProxyServer() {
+    protected LegacyProxyServer createProxyServer() {
         return new ProxyServer(0);
     }
 

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -29,9 +29,9 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.exception.ProxyExistsException;
+import net.lightbody.bmp.proxy.LegacyProxyServer;
 import net.lightbody.bmp.proxy.ProxyManager;
 import net.lightbody.bmp.exception.ProxyPortsExhaustedException;
-import net.lightbody.bmp.proxy.ProxyServer;
 import net.lightbody.bmp.proxy.http.BrowserMobHttpRequest;
 import net.lightbody.bmp.proxy.http.BrowserMobHttpResponse;
 import net.lightbody.bmp.proxy.http.RequestInterceptor;
@@ -55,7 +55,7 @@ public class ProxyResource {
     @Get
     public Reply<?> getProxies() {
         Collection<ProxyDescriptor> proxyList = new ArrayList<ProxyDescriptor> ();
-        for (ProxyServer proxy : proxyManager.get()) {
+        for (LegacyProxyServer proxy : proxyManager.get()) {
             proxyList.add(new ProxyDescriptor(proxy.getPort()));
         }
         return Reply.with(new ProxyListDescriptor(proxyList)).as(Json.class);
@@ -79,7 +79,7 @@ public class ProxyResource {
         Integer paramPort = request.param("port") == null ? null : Integer.parseInt(request.param("port"));
         LOG.debug("POST proxy instance on bindAddress `{}` & port `{}`", 
                 paramBindAddr, paramPort);
-        ProxyServer proxy;
+        LegacyProxyServer proxy;
         try{
             proxy = proxyManager.create(options, paramPort, paramBindAddr);            
         }catch(ProxyExistsException ex){
@@ -97,7 +97,7 @@ public class ProxyResource {
     @Get
     @At("/:port/har")
     public Reply<?> getHar(@Named("port") int port) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -110,7 +110,7 @@ public class ProxyResource {
     @Put
     @At("/:port/har")
     public Reply<?> newHar(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -136,7 +136,7 @@ public class ProxyResource {
     @Put
     @At("/:port/har/pageRef")
     public Reply<?> setPage(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -151,7 +151,7 @@ public class ProxyResource {
     @Get
     @At("/:port/blacklist")
     public Reply<?> getBlacklist(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -162,7 +162,7 @@ public class ProxyResource {
     @Put
     @At("/:port/blacklist")
     public Reply<?> blacklist(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -178,7 +178,7 @@ public class ProxyResource {
     @Delete
     @At("/:port/blacklist")
     public Reply<?> clearBlacklist(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -190,7 +190,7 @@ public class ProxyResource {
     @Get
     @At("/:port/whitelist")
     public Reply<?> getWhitelist(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -201,7 +201,7 @@ public class ProxyResource {
     @Put
     @At("/:port/whitelist")
     public Reply<?> whitelist(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -216,7 +216,7 @@ public class ProxyResource {
     @Delete
     @At("/:port/whitelist")
     public Reply<?> clearWhitelist(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -228,7 +228,7 @@ public class ProxyResource {
     @Post
     @At("/:port/auth/basic/:domain")
     public Reply<?> autoBasicAuth(@Named("port") int port, @Named("domain") String domain, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -242,7 +242,7 @@ public class ProxyResource {
     @Post
     @At("/:port/headers")
     public Reply<?> updateHeaders(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -259,7 +259,7 @@ public class ProxyResource {
     @Post
     @At("/:port/interceptor/response")
     public Reply<?> addResponseInterceptor(@Named("port") int port, Request<String> request) throws IOException, ScriptException {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -295,7 +295,7 @@ public class ProxyResource {
     @Post
     @At("/:port/interceptor/request")
     public Reply<?> addRequestInterceptor(@Named("port") int port, Request<String> request) throws IOException, ScriptException {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         request.readTo(baos);
@@ -326,7 +326,7 @@ public class ProxyResource {
     @Put
     @At("/:port/limit")
     public Reply<?> limit(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -393,7 +393,7 @@ public class ProxyResource {
     @Get
     @At("/:port/limit")
     public Reply<?> getLimits(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }                
@@ -403,7 +403,7 @@ public class ProxyResource {
     @Put
     @At("/:port/timeout")
     public Reply<?> timeout(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -438,7 +438,7 @@ public class ProxyResource {
     @Delete
     @At("/:port")
     public Reply<?> delete(@Named("port") int port) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -450,7 +450,7 @@ public class ProxyResource {
     @Post
     @At("/:port/hosts")
     public Reply<?> remapHosts(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -472,7 +472,7 @@ public class ProxyResource {
     @Put
     @At("/:port/wait")
     public Reply<?> wait(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -486,7 +486,7 @@ public class ProxyResource {
     @Delete
     @At("/:port/dns/cache")
     public Reply<?> clearDnsCache(@Named("port") int port) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -498,7 +498,7 @@ public class ProxyResource {
     @Put
     @At("/:port/rewrite")
     public Reply<?> rewriteUrl(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -512,7 +512,7 @@ public class ProxyResource {
     @Delete
     @At("/:port/rewrite")
     public Reply<?> clearRewriteRules(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }
@@ -524,7 +524,7 @@ public class ProxyResource {
     @Put
     @At("/:port/retry")
     public Reply<?> retryCount(@Named("port") int port, Request<String> request) {
-        ProxyServer proxy = proxyManager.get(port);
+        LegacyProxyServer proxy = proxyManager.get(port);
         if (proxy == null) {
             return Reply.saying().notFound();
         }

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/guice/ConfigModule.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/guice/ConfigModule.java
@@ -3,12 +3,14 @@ package net.lightbody.bmp.proxy.guice;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import java.io.IOException;
-import static java.util.Arrays.asList;
-import java.util.List;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import net.lightbody.bmp.proxy.LegacyProxyServer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class ConfigModule implements Module {
     private String[] args;
@@ -44,7 +46,7 @@ public class ConfigModule implements Module {
                       .ofType(Integer.class)
                       .defaultsTo(0);
 
-        parser.acceptsAll(asList("help", "?"), "This help text");
+        parser.acceptsAll(Arrays.asList("help", "?"), "This help text");
 
         OptionSet options = parser.parse(args);
 
@@ -84,11 +86,7 @@ public class ConfigModule implements Module {
         binder.bind(Key.get(Integer.class, new NamedImpl("minPort"))).toInstance(minPort);
         binder.bind(Key.get(Integer.class, new NamedImpl("maxPort"))).toInstance(maxPort);                 
         binder.bind(Key.get(Integer.class, new NamedImpl("ttl"))).toInstance(ttlSpec.value(options));
-        
-        /*
-         * Init User Agent String Parser, update of the UAS datastore will run in background.
-         */
-        // temporarily disabled because user-agent-string.info no longer exists
-        //BrowserMobHttpClient.getUserAgentStringParser();
+
+        binder.bind(LegacyProxyServer.class).toProvider(LegacyProxyServerProvider.class);
     }
 }

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/guice/LegacyProxyServerProvider.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/guice/LegacyProxyServerProvider.java
@@ -1,0 +1,12 @@
+package net.lightbody.bmp.proxy.guice;
+
+import com.google.inject.Provider;
+import net.lightbody.bmp.proxy.LegacyProxyServer;
+import net.lightbody.bmp.proxy.ProxyServer;
+
+public class LegacyProxyServerProvider implements Provider<LegacyProxyServer> {
+    @Override
+    public LegacyProxyServer get() {
+        return new ProxyServer();
+    }
+}

--- a/browsermob-rest/src/test/java/net/lightbody/bmp/proxy/ExpiringProxyTest.java
+++ b/browsermob-rest/src/test/java/net/lightbody/bmp/proxy/ExpiringProxyTest.java
@@ -1,7 +1,6 @@
 package net.lightbody.bmp.proxy;
 
-import com.google.inject.Provider;
-import org.junit.Before;
+import net.lightbody.bmp.proxy.guice.LegacyProxyServerProvider;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -15,20 +14,15 @@ public class ExpiringProxyTest {
     public void testExpiredProxyStops() throws InterruptedException {
         int minPort = new Random().nextInt(50000) + 10000;
 
-        ProxyManager proxyManager = new ProxyManager(new Provider<ProxyServer>() {
-            @Override
-            public ProxyServer get() {
-                return new ProxyServer();
-            }
-        },
+        ProxyManager proxyManager = new ProxyManager(new LegacyProxyServerProvider(),
                 minPort,
                 minPort + 100,
                 2);
 
-        ProxyServer proxy = proxyManager.create(Collections.<String, String>emptyMap());
+        LegacyProxyServer proxy = proxyManager.create(Collections.<String, String>emptyMap());
         int port = proxy.getPort();
 
-        ProxyServer retrievedProxy = proxyManager.get(port);
+        LegacyProxyServer retrievedProxy = proxyManager.get(port);
 
         assertEquals("ProxyManager did not return the expected proxy instance", proxy, retrievedProxy);
 
@@ -38,7 +32,7 @@ public class ExpiringProxyTest {
         int newPort = proxyManager.create(Collections.<String, String>emptyMap()).getPort();
         proxyManager.delete(newPort);
 
-        ProxyServer expiredProxy = proxyManager.get(port);
+        LegacyProxyServer expiredProxy = proxyManager.get(port);
 
         assertNull("ProxyManager did not expire proxy as expected", expiredProxy);
     }
@@ -47,20 +41,15 @@ public class ExpiringProxyTest {
     public void testZeroTtlProxyDoesNotExpire() throws InterruptedException {
         int minPort = new Random().nextInt(50000) + 10000;
 
-        ProxyManager proxyManager = new ProxyManager(new Provider<ProxyServer>() {
-            @Override
-            public ProxyServer get() {
-                return new ProxyServer();
-            }
-        },
+        ProxyManager proxyManager = new ProxyManager(new LegacyProxyServerProvider(),
                 minPort,
                 minPort + 100,
                 0);
 
-        ProxyServer proxy = proxyManager.create(Collections.<String, String>emptyMap());
+        LegacyProxyServer proxy = proxyManager.create(Collections.<String, String>emptyMap());
         int port = proxy.getPort();
 
-        ProxyServer retrievedProxy = proxyManager.get(port);
+        LegacyProxyServer retrievedProxy = proxyManager.get(port);
 
         assertEquals("ProxyManager did not return the expected proxy instance", proxy, retrievedProxy);
 
@@ -70,7 +59,7 @@ public class ExpiringProxyTest {
         int newPort = proxyManager.create(Collections.<String, String>emptyMap()).getPort();
         proxyManager.delete(newPort);
 
-        ProxyServer nonExpiredProxy = proxyManager.get(port);
+        LegacyProxyServer nonExpiredProxy = proxyManager.get(port);
 
         assertEquals("ProxyManager did not return the expected proxy instance", proxy, nonExpiredProxy);
     }

--- a/browsermob-rest/src/test/java/net/lightbody/bmp/proxy/ProxyPortAssignmentTest.java
+++ b/browsermob-rest/src/test/java/net/lightbody/bmp/proxy/ProxyPortAssignmentTest.java
@@ -19,7 +19,7 @@ public class ProxyPortAssignmentTest extends ProxyManagerTest {
     @Test
     public void testAutoAssignment() throws Exception {
         int[] ports = {9091, 9092, 9093};
-        ProxyServer p;
+        LegacyProxyServer p;
         for(int port : ports){
             p = proxyManager.create(new HashMap<String, String>());
             assertEquals(port, p.getPort());
@@ -44,7 +44,7 @@ public class ProxyPortAssignmentTest extends ProxyManagerTest {
     
     @Test
     public void testManualAssignment() throws Exception {
-        ProxyServer p = proxyManager.create(new HashMap<String, String>(), 9094);
+        LegacyProxyServer p = proxyManager.create(new HashMap<String, String>(), 9094);
         assertEquals(9094, p.getPort());
         try{            
             proxyManager.create(new HashMap<String, String>(), 9094);            

--- a/browsermob-rest/src/test/java/net/lightbody/bmp/proxy/test/util/ProxyManagerTest.java
+++ b/browsermob-rest/src/test/java/net/lightbody/bmp/proxy/test/util/ProxyManagerTest.java
@@ -2,8 +2,8 @@ package net.lightbody.bmp.proxy.test.util;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import net.lightbody.bmp.proxy.LegacyProxyServer;
 import net.lightbody.bmp.proxy.ProxyManager;
-import net.lightbody.bmp.proxy.ProxyServer;
 import net.lightbody.bmp.proxy.guice.ConfigModule;
 import org.junit.After;
 import org.junit.Before;
@@ -21,7 +21,7 @@ public abstract class ProxyManagerTest {
 
     @After
     public void tearDown() throws Exception {  
-        for(ProxyServer p : proxyManager.get()){
+        for(LegacyProxyServer p : proxyManager.get()){
             try{
                 proxyManager.delete(p.getPort());
             }catch(Exception e){ }


### PR DESCRIPTION
This PR changes all existing ProxyServer references to use LegacyProxyServer, to prepare for swapping out the Jetty-based ProxyServer implementation with the upcoming LittleProxy implementation.