### PR TITLE
Selenium version update

### DIFF
--- a/browsermob-core/pom.xml
+++ b/browsermob-core/pom.xml
@@ -146,16 +146,16 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.detro</groupId>
+            <groupId>com.codeborne</groupId>
             <artifactId>phantomjsdriver</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-phantom-driver</artifactId>
-            <version>1.1.3.Final</version>
+            <version>1.1.4.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <slf4j.version>1.7.10</slf4j.version>
-        <selenium.version>2.43.1</selenium.version>
+        <selenium.version>2.45.0</selenium.version>
 
         <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
 


### PR DESCRIPTION
This should preserve compatibility with the latest Firefox, which was broken using Selenium 2.43.1.