### PR TITLE
Enable groovy unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
         <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
 
         <log4j.version>2.2</log4j.version>
+
+        <groovy.version>2.4.3</groovy.version>
     </properties>
 
     <build>
@@ -80,9 +82,22 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.2</version>
                     <configuration>
+                        <compilerId>groovy-eclipse-compiler</compilerId>
                         <source>1.7</source>
                         <target>1.7</target>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-eclipse-compiler</artifactId>
+                            <version>2.9.2-01</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-eclipse-batch</artifactId>
+                            <version>${groovy.version}-01</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -217,8 +232,21 @@
                 <artifactId>selenium-firefox-driver</artifactId>
                 <version>${selenium.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <profiles>
         <profile>


### PR DESCRIPTION
This enables using groovy to write unit tests. With the new interface now merged to master (and documentation on the way!), I'm just about ready to create a PR for the initial LittleProxy integration. I want to include several new unit tests for the new interface and new functionality before officially releasing it, and using groovy will speed up that process.

As a side effect of this, the Eclipse compiler will now compile the java source instead of javac. Practically speaking this should have no effect whatsoever.