### PR TITLE
Made selenium dependency optional in browsermob-core

### DIFF
--- a/browsermob-core/pom.xml
+++ b/browsermob-core/pom.xml
@@ -105,8 +105,14 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-api</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The selenium-api dependency can be made optional to reduce the size of the release package, as well as to exclude unused code when not using BMP in Selenium tests. Since Selenium tests will already include a dependency on selenium-api, this removal should be harmless.