### PR TITLE
Bump netty version and reduce LP implementation's transitive dependencies.

### DIFF
--- a/browsermob-core-littleproxy/pom.xml
+++ b/browsermob-core-littleproxy/pom.xml
@@ -11,7 +11,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>net.lightbody.bmp</groupId>
     <artifactId>browsermob-core-littleproxy</artifactId>
     <name>BrowserMob Proxy Core (LittleProxy) Module</name>
 
@@ -78,6 +77,22 @@
             <groupId>net.lightbody.bmp</groupId>
             <artifactId>browsermob-core</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <!-- Due to usage in LegacyProxyServer and BrowserMobProxyServer, this dependency needs to be given "provided" scope.
+                     It is not used by the BMP LittleProxy implementation itself. -->
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.lightbody.bmp</groupId>
@@ -92,10 +107,6 @@
                     <groupId>org.slf4j</groupId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.littleshoot</groupId>
-                    <artifactId>dnsjava</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.barchart.udt</groupId>
                     <artifactId>barchart-udt-bundle</artifactId>
                 </exclusion>
@@ -108,6 +119,21 @@
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <!-- Still exclude transitive dependencies to avoid polluting test scope -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -146,7 +172,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-phantom-driver</artifactId>
-            <version>1.1.3.Final</version>
             <scope>test</scope>
         </dependency>
 
@@ -201,5 +226,12 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Due to usage in LegacyProxyServer and BrowserMobProxyServer, this dependency needs to be given "provided" scope.
+                     It is not used by the BMP LittleProxy implementation itself. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/browsermob-core/pom.xml
+++ b/browsermob-core/pom.xml
@@ -42,7 +42,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-
                 <executions>
                     <execution>
                         <id>test-jar</id>
@@ -100,7 +99,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
             <exclusions>
                 <exclusion>
                     <artifactId>commons-logging</artifactId>
@@ -111,7 +109,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.3.4</version>
         </dependency>
 
         <dependency>
@@ -210,7 +207,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-phantom-driver</artifactId>
-            <version>1.1.4.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,19 +255,25 @@
             <dependency>
                 <groupId>net.lightbody.bmp</groupId>
                 <artifactId>littleproxy</artifactId>
-                <version>1.1.0-beta1-bmp-SNAPSHOT</version>
+                <version>1.1.0-beta-bmp-1-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-netty</artifactId>
-                <version>3.9.7</version>
+                <version>3.9.11</version>
                 <exclusions>
                     <exclusion>
                         <groupId>ch.qos.logback</groupId>
                         <artifactId>logback-classic</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian.extension</groupId>
+                <artifactId>arquillian-phantom-driver</artifactId>
+                <version>1.1.4.Final</version>
             </dependency>
 
             <dependency>
@@ -292,6 +298,23 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>4.0.27.Final</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>4.3.4</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
This should reduce unnecessary dependencies when using only the LittleProxy implementation. Most notably, this eliminates the dependency on servlet-api 2.5, which will avoid the servlet-api conflicts reported in issue #103 (and others).

It also bumps the netty version to 4.0.27, the latest stable version.