### PR TITLE
Allow addRequestFilter/addResponseFilter without aggregated messages

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -1126,11 +1126,21 @@ public class BrowserMobProxyServer implements BrowserMobProxy, LegacyProxyServer
         filterFactories.add(filterFactory);
     }
 
+    /**
+     * <b>Note:</b> The current implementation of this method forces a maximum response size of 2 MiB. To adjust the maximum response size, or
+     * to disable aggregation (which disallows access to the {@link net.lightbody.bmp.util.HttpMessageContents}), you may add the filter source
+     * directly: <code>addFirstHttpFilterFactory(new ResponseFilterAdapter.FilterSource(filter, bufferSizeInBytes));</code>
+     */
     @Override
     public void addResponseFilter(ResponseFilter filter) {
         addLastHttpFilterFactory(new ResponseFilterAdapter.FilterSource(filter));
     }
 
+    /**
+     * <b>Note:</b> The current implementation of this method forces a maximum request size of 2 MiB. To adjust the maximum request size, or
+     * to disable aggregation (which disallows access to the {@link net.lightbody.bmp.util.HttpMessageContents}), you may add the filter source
+     * directly: <code>addFirstHttpFilterFactory(new RequestFilterAdapter.FilterSource(filter, bufferSizeInBytes));</code>
+     */
     @Override
     public void addRequestFilter(RequestFilter filter) {
         addFirstHttpFilterFactory(new RequestFilterAdapter.FilterSource(filter));


### PR DESCRIPTION
This allows RequestFilter and ResponseFilter to fire when request/response aggregation has been disabled by setting a size of 0 for the request/response buffers. HttpMessageContents will be null when aggregation is not enabled.