### PR TITLE
Add deflate support

### DIFF
--- a/browsermob-core-littleproxy/pom.xml
+++ b/browsermob-core-littleproxy/pom.xml
@@ -210,6 +210,12 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- deflate support; not a transitive dependency of netty out-of-the-box -->
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jzlib</artifactId>
+        </dependency>
+
         <!-- Due to usage in LegacyProxyServer and BrowserMobProxyServer, this dependency needs to be given "provided" scope.
                      It is not used by the BMP LittleProxy implementation itself. -->
         <dependency>

--- a/browsermob-dist/pom.xml
+++ b/browsermob-dist/pom.xml
@@ -158,7 +158,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>2.5.3</version>
+                        <version>2.5.4</version>
                         <executions>
                             <execution>
                                 <id>make-bundles</id>

--- a/pom.xml
+++ b/pom.xml
@@ -311,10 +311,17 @@
                 <artifactId>httpclient</artifactId>
                 <version>4.3.4</version>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>4.3.4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jzlib</artifactId>
+                <version>1.1.3</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <slf4j.version>1.7.10</slf4j.version>
+        <slf4j.version>1.7.12</slf4j.version>
         <selenium.version>2.45.0</selenium.version>
 
         <jackson.version>2.4.4</jackson.version>
 
-        <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
+        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
 
         <log4j.version>2.2</log4j.version>
 
@@ -83,7 +83,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.3</version>
                     <configuration>
                         <compilerId>groovy-eclipse-compiler</compilerId>
                         <source>1.7</source>
@@ -129,7 +129,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.1</version>
+                    <version>2.10.3</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
@@ -261,7 +261,7 @@
             <dependency>
                 <groupId>org.mock-server</groupId>
                 <artifactId>mockserver-netty</artifactId>
-                <version>3.9.11</version>
+                <version>3.9.15</version>
                 <exclusions>
                     <exclusion>
                         <groupId>ch.qos.logback</groupId>
@@ -368,7 +368,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <configuration>
                     <effort>Max</effort>
                 </configuration>
@@ -376,7 +376,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
This adds com.jcraft:jzlib as a dependency, since netty (via LittleProxy) doesn't transitively include it. Thanks to Alex Johnson who reported the issue!

This PR also updates some plugin versions, and updates to the latest slf4j (should be binary compatible for projects using previous versions).