### PR TITLE
HostResolver updates

### DIFF
--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
@@ -8,7 +8,8 @@ import net.lightbody.bmp.core.har.HarContent
 import net.lightbody.bmp.core.har.HarCookie
 import net.lightbody.bmp.core.har.HarEntry
 import net.lightbody.bmp.core.har.HarNameValuePair
-import net.lightbody.bmp.proxy.dns.HostResolver
+import net.lightbody.bmp.proxy.dns.AdvancedHostResolver
+import net.lightbody.bmp.proxy.dns.BasicHostResolver
 import net.lightbody.bmp.proxy.test.util.MockServerTest
 import net.lightbody.bmp.proxy.test.util.ProxyServerTest
 import net.lightbody.bmp.proxy.util.IOUtils
@@ -53,7 +54,7 @@ class NewHarTest extends MockServerTest {
     @Test
     void testDnsTimingPopulated() {
         // mock up a resolver with a DNS resolution delay
-        HostResolver mockResolver = mock(HostResolver.class);
+        AdvancedHostResolver mockResolver = mock(AdvancedHostResolver.class);
         when(mockResolver.resolve("localhost")).then(new Answer<Collection<InetAddress>>() {
             @Override
             public Collection<InetAddress> answer(InvocationOnMock invocationOnMock) throws Throwable {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -6,6 +6,7 @@ import net.lightbody.bmp.filters.ResponseFilter;
 import net.lightbody.bmp.proxy.BlacklistEntry;
 import net.lightbody.bmp.proxy.CaptureType;
 import net.lightbody.bmp.proxy.auth.AuthType;
+import net.lightbody.bmp.proxy.dns.AdvancedHostResolver;
 import net.lightbody.bmp.proxy.dns.HostResolver;
 import org.littleshoot.proxy.HttpFiltersSource;
 
@@ -462,20 +463,17 @@ public interface BrowserMobProxy {
     /**
      * Sets the resolver that will be used to look up host names. To chain multiple resolvers, wrap a list
      * of resolvers in a {@link net.lightbody.bmp.proxy.dns.ChainedHostResolver}.
-     * <p/>
-     * <b>Note:</b> Host name remapping and DNS cache manipulation functionality is available via the {@link net.lightbody.bmp.proxy.dns.AdvancedHostResolver}
-     * interface, which implements {@link net.lightbody.bmp.proxy.dns.HostResolver}.
      *
-     * @param resolver ordered collection of host name resolvers
+     * @param resolver host name resolver
      */
-    void setHostNameResolver(HostResolver resolver);
+    void setHostNameResolver(AdvancedHostResolver resolver);
 
     /**
      * Returns the current host name resolver.
      *
-     * @return the current host name resolver
+     * @return current host name resolver
      */
-    HostResolver getHostNameResolver();
+    AdvancedHostResolver getHostNameResolver();
 
     /**
      * Waits for existing network traffic to stop, and for the specified quietPeriod to elapse. Returns true if there is no network traffic

--- a/browsermob-core/src/main/java/net/lightbody/bmp/client/ClientUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/client/ClientUtil.java
@@ -19,7 +19,7 @@ import java.net.UnknownHostException;
 public class ClientUtil {
     /**
      * Creates a {@link net.lightbody.bmp.proxy.dns.NativeCacheManipulatingResolver} instance that can be used when
-     * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.HostResolver)}.
+     * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.AdvancedHostResolver)}.
      *
      * @return a new NativeCacheManipulatingResolver
      */
@@ -29,32 +29,32 @@ public class ClientUtil {
 
     /**
      * Creates a {@link net.lightbody.bmp.proxy.dns.NativeResolver} instance that <b>does not support cache manipulation</b> that can be used when
-     * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.HostResolver)}.
+     * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.AdvancedHostResolver)}.
      *
      * @return a new NativeResolver
      */
-    public static final AdvancedHostResolver createNativeResolver() {
+    public static AdvancedHostResolver createNativeResolver() {
         return new NativeResolver();
     }
 
     /**
      * Creates a {@link net.lightbody.bmp.proxy.dns.DnsJavaResolver} instance that can be used when
-     * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.HostResolver)}.
+     * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.AdvancedHostResolver)}.
      *
      * @return a new DnsJavaResolver
      */
-    public static final AdvancedHostResolver createDnsJavaResolver() {
+    public static AdvancedHostResolver createDnsJavaResolver() {
         return new DnsJavaResolver();
     }
 
     /**
      * Creates a {@link net.lightbody.bmp.proxy.dns.ChainedHostResolver} instance that first attempts to resolve a hostname using a
      * {@link net.lightbody.bmp.proxy.dns.DnsJavaResolver}, then uses {@link net.lightbody.bmp.proxy.dns.NativeCacheManipulatingResolver}.
-     * Can be used when calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.HostResolver)}.
+     * Can be used when calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.AdvancedHostResolver)}.
      *
      * @return a new ChainedHostResolver that resolves addresses first using a DnsJavaResolver, then using a NativeCacheManipulatingResolver
      */
-    public static final AdvancedHostResolver createDnsJavaWithNativeFallbackResolver() {
+    public static AdvancedHostResolver createDnsJavaWithNativeFallbackResolver() {
         return new ChainedHostResolver(ImmutableList.of(new DnsJavaResolver(), new NativeCacheManipulatingResolver()));
     }
 

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -16,7 +16,6 @@ import net.lightbody.bmp.filters.RequestFilter;
 import net.lightbody.bmp.filters.ResponseFilter;
 import net.lightbody.bmp.proxy.auth.AuthType;
 import net.lightbody.bmp.proxy.dns.AdvancedHostResolver;
-import net.lightbody.bmp.proxy.dns.HostResolver;
 import net.lightbody.bmp.proxy.http.BrowserMobHttpClient;
 import net.lightbody.bmp.proxy.http.RequestInterceptor;
 import net.lightbody.bmp.proxy.http.ResponseInterceptor;
@@ -763,12 +762,12 @@ public class ProxyServer implements LegacyProxyServer, BrowserMobProxy {
     }
 
     @Override
-    public void setHostNameResolver(HostResolver resolver) {
+    public void setHostNameResolver(AdvancedHostResolver resolver) {
         client.setResolver(resolver);
     }
 
     @Override
-    public HostResolver getHostNameResolver() {
+    public AdvancedHostResolver getHostNameResolver() {
         return client.getResolver();
     }
 

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/BasicHostResolver.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/BasicHostResolver.java
@@ -1,0 +1,57 @@
+package net.lightbody.bmp.proxy.dns;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An {@link AdvancedHostResolver} that throws UnsupportedOperationException on all methods except {@link HostResolver#resolve(String)}.
+ * Use this class to supply a {@link HostResolver} to {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(AdvancedHostResolver)}
+ * if you do not need {@link AdvancedHostResolver} functionality.
+ */
+public abstract class BasicHostResolver implements AdvancedHostResolver {
+    @Override
+    public void remapHosts(Map<String, String> hostRemappings) {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public void remapHost(String originalHost, String remappedHost) {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public void removeHostRemapping(String originalHost) {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public void clearHostRemappings() {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public Map<String, String> getHostRemappings() {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public Collection<String> getOriginalHostnames(String remappedHost) {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public void clearDNSCache() {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public void setPositiveDNSCacheTimeout(int timeout, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+
+    @Override
+    public void setNegativeDNSCacheTimeout(int timeout, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException(new Throwable().getStackTrace()[0].getMethodName() + " is not supported by this host resolver (" + this.getClass().getName() + ")");
+    }
+}

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/HostResolver.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/HostResolver.java
@@ -16,5 +16,5 @@ public interface HostResolver {
      * @param host host to resolve
      * @return resolved InetAddresses, or an empty collection if no addresses were found
      */
-    public Collection<InetAddress> resolve(String host);
+    Collection<InetAddress> resolve(String host);
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -16,7 +16,6 @@ import net.lightbody.bmp.proxy.BlacklistEntry;
 import net.lightbody.bmp.proxy.RewriteRule;
 import net.lightbody.bmp.proxy.Whitelist;
 import net.lightbody.bmp.proxy.dns.AdvancedHostResolver;
-import net.lightbody.bmp.proxy.dns.HostResolver;
 import net.lightbody.bmp.proxy.jetty.util.MultiMap;
 import net.lightbody.bmp.proxy.jetty.util.UrlEncoded;
 import net.lightbody.bmp.proxy.util.BrowserMobProxyUtil;
@@ -1548,11 +1547,11 @@ public class BrowserMobHttpClient {
         return captureHeaders;
     }
 
-    public HostResolver getResolver() {
+    public AdvancedHostResolver getResolver() {
         return resolverWrapper.getResolver();
     }
 
-    public void setResolver(HostResolver resolver) {
+    public void setResolver(AdvancedHostResolver resolver) {
         resolverWrapper.setResolver(resolver);
     }
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/LegacyHostResolverAdapter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/http/LegacyHostResolverAdapter.java
@@ -1,6 +1,6 @@
 package net.lightbody.bmp.proxy.http;
 
-import net.lightbody.bmp.proxy.dns.HostResolver;
+import net.lightbody.bmp.proxy.dns.AdvancedHostResolver;
 import org.apache.http.conn.DnsResolver;
 
 import java.net.InetAddress;
@@ -8,22 +8,22 @@ import java.net.UnknownHostException;
 
 /**
  * An adapter that allows the legacy {@link net.lightbody.bmp.proxy.http.BrowserMobHttpClient} to use the new
- * {@link net.lightbody.bmp.proxy.dns.HostResolver} implementations. In addition to implementing the
+ * {@link net.lightbody.bmp.proxy.dns.AdvancedHostResolver} implementations. In addition to implementing the
  * {@link org.apache.http.conn.DnsResolver} interface that BrowserMobHttpClient needs, this adapter also populates timing and address
  * info in the RequestInfo class.
  */
 public class LegacyHostResolverAdapter implements DnsResolver {
-    private volatile HostResolver resolver;
+    private volatile AdvancedHostResolver resolver;
 
-    public LegacyHostResolverAdapter(HostResolver resolver) {
+    public LegacyHostResolverAdapter(AdvancedHostResolver resolver) {
         this.resolver = resolver;
     }
 
-    public void setResolver(HostResolver resolver) {
+    public void setResolver(AdvancedHostResolver resolver) {
         this.resolver = resolver;
     }
 
-    public HostResolver getResolver() {
+    public AdvancedHostResolver getResolver() {
         return resolver;
     }
 


### PR DESCRIPTION
This makes AdvancedHostResolver the only used supported by the BrowserMobProxy interface. This eliminates the need to cast to AdvancedHostResolver when attempting to use the cache-manipulating and other features of the built-in resolvers after calling BrowserMobProxy.getHostNameResolver().

This PR also makes the native JDK resolver the default resolver in the LittleProxy implementation and disables dnsjava by default. The legacy implementation continues to use dnsjava with native fallback by default.