### PR TITLE
Replaced originalRequest on filters with new HttpMessageInfo object

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ For most use cases, including inspecting and modifying requests/responses, `addR
 ```java
 	proxy.addRequestFilter(new RequestFilter() {
             @Override
-            public HttpResponse filterRequest(HttpRequest request, HttpMessageContents contents, HttpRequest originalRequest) {
+            public HttpResponse filterRequest(HttpRequest request, HttpMessageContents contents, HttpMessageInfo messageInfo) {
                 if (request.getUri().equals("/some-endpoint-to-intercept")) {
                     // retrieve the existing message contents as a String or, for binary contents, as a byte[]
                     String messageContents = contents.getTextContents();
@@ -271,7 +271,7 @@ For most use cases, including inspecting and modifying requests/responses, `addR
         // responses are equally as simple:
         proxy.addResponseFilter(new ResponseFilter() {
             @Override
-            public void filterResponse(HttpResponse response, HttpMessageContents contents, HttpRequest originalRequest) {
+            public void filterResponse(HttpResponse response, HttpMessageContents contents, HttpMessageInfo messageInfo) {
                 if (/*...some filtering criteria...*/) {
                     contents.setTextContents("This message body will appear in all responses!");
                 }
@@ -281,7 +281,7 @@ For most use cases, including inspecting and modifying requests/responses, `addR
 
 With Java 8, the syntax is even more concise:
 ```java
-        proxy.addResponseFilter((response, contents, originalRequest) -> {
+        proxy.addResponseFilter((response, contents, messageInfo) -> {
             if (/*...some filtering criteria...*/) {
                 contents.setTextContents("This message body will appear in all responses!");
             }
@@ -298,7 +298,7 @@ When running the REST API with LittleProxy enabled, you cannot use the legacy `/
 
 ##### Request filters
 
-Javascript request filters have access to the variables `request` (type `io.netty.handler.codec.http.HttpRequest`), `contents` (type `net.lightbody.bmp.util.HttpMessageContents`), and `originalRequest` (type `io.netty.handler.codec.http.HttpRequest`). `originalRequest` contains the original request received from the client and does not reflect any changes made by previous filters. If the javascript returns an object of type `io.netty.handler.codec.http.HttpResponse`, the HTTP request will "short-circuit" and return the response immediately.
+Javascript request filters have access to the variables `request` (type `io.netty.handler.codec.http.HttpRequest`), `contents` (type `net.lightbody.bmp.util.HttpMessageContents`), and `messageInfo` (type `net.lightbody.bmp.util.HttpMessageInfo`). `messageInfo` contains additional information about the message, including whether the message is sent over HTTP or HTTPS, as well as the original request received from the client before any changes made by previous filters. If the javascript returns an object of type `io.netty.handler.codec.http.HttpResponse`, the HTTP request will "short-circuit" and return the response immediately.
 
 **Example: Modify User-Agent header**
 
@@ -308,7 +308,7 @@ curl -i -X POST -H 'Content-Type: text/plain' -d "request.headers().remove('User
 
 ##### Response filters
 
-Javascript response filters have access to the variables `response` (type `io.netty.handler.codec.http.HttpResponse`), `contents` (type `net.lightbody.bmp.util.HttpMessageContents`), and `originalRequest` (type `io.netty.handler.codec.http.HttpRequest`). As in the request filter, `originalRequest` contains the original request received from the client and does not reflect any changes made by previous filters.
+Javascript response filters have access to the variables `response` (type `io.netty.handler.codec.http.HttpResponse`), `contents` (type `net.lightbody.bmp.util.HttpMessageContents`), and `messageInfo` (type `net.lightbody.bmp.util.HttpMessageInfo`). As in the request filter, `messageInfo` contains additional information about the message.
 
 **Example: Modify response body**
 

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -349,23 +349,7 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
         //     url [string] - Absolute URL of the request (fragments are not included).
         // the URI on the httpRequest may only identify the path of the resource, so find the full URL.
         // the full URL consists of the scheme + host + port (if non-standard) + path + query params + fragment.
-        // Scheme: the scheme (HTTP/HTTPS) may or may not be part of the request, and so must be generated based on the
-        //   type of connection.
-        // Host and Port: for HTTP requests, the host and port can be read from the request itself using the URI and/or
-        //   Host header. for HTTPS requests, the host and port are not available in the request. by using the
-        //   getRequestHostAndPort() helper method in HttpsAwareFiltersAdapter, we can capture the host and port for
-        //   HTTPS requests.
-        // Path + Query Params + Fragment: these elements are contained in the HTTP request
-        String url;
-        if (isHttps()) {
-            String hostAndPort = getRequestHostAndPort();
-            String path = BrowserMobHttpUtil.getPathFromRequest(httpRequest);
-            url = "https://" + hostAndPort + path;
-        } else {
-            String hostAndPort = BrowserMobHttpUtil.getHostAndPortFromRequest(httpRequest);
-            String path = BrowserMobHttpUtil.getPathFromRequest(httpRequest);
-            url = "http://" + hostAndPort + path;
-        }
+        String url = getFullUrl(httpRequest);
 
         HarRequest request = new HarRequest(httpRequest.getMethod().toString(), url, httpRequest.getProtocolVersion().text());
         harEntry.setRequest(request);
@@ -625,13 +609,7 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
      * @param httpRequest HTTP request to take the hostname from
      */
     protected void populateAddressFromCache(HttpRequest httpRequest) {
-        String serverHost;
-        if (isHttps()) {
-            HostAndPort hostAndPort = HostAndPort.fromString(getRequestHostAndPort());
-            serverHost = hostAndPort.getHostText();
-        } else {
-            serverHost = BrowserMobHttpUtil.getHostFromRequest(httpRequest);
-        }
+        String serverHost = getHostAndPort(httpRequest);
 
         if (serverHost != null && !serverHost.isEmpty()) {
             String resolvedAddress = resolvedAddresses.get(serverHost);

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
@@ -1,16 +1,18 @@
 package net.lightbody.bmp.filters;
 
+import com.google.common.net.HostAndPort;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import net.lightbody.bmp.util.BrowserMobHttpUtil;
 import org.littleshoot.proxy.HttpFiltersAdapter;
 
 /**
  * The HttpsAwareFiltersAdapter exposes the original host and the "real" host (after filter modifications) to filters for HTTPS
  * requets. HTTPS requests do not normally contain the host in the URI, and the Host header may be missing or spoofed.
  * <p/>
- * <b>Note:</b> The {@link #getRequestHostAndPort()} and {@link #getOriginalRequestHostAndPort()} methods can only be
+ * <b>Note:</b> The {@link #getHttpsRequestHostAndPort()} and {@link #getHttpsOriginalRequestHostAndPort()} methods can only be
  * called when the request is an HTTPS request. Otherwise they will throw an IllegalStateException.
  */
 public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
@@ -44,7 +46,7 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
      * @return host and port of this HTTPS request
      * @throws IllegalStateException if this is not an HTTPS request
      */
-    public String getRequestHostAndPort() throws IllegalStateException {
+    public String getHttpsRequestHostAndPort() throws IllegalStateException {
         if (!isHttps()) {
             throw new IllegalStateException("Request is not HTTPS. Cannot get host and port on non-HTTPS request using this method.");
         }
@@ -60,12 +62,71 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
      * @return host and port of this HTTPS request
      * @throws IllegalStateException if this is not an HTTPS request
      */
-    public String getOriginalRequestHostAndPort() throws IllegalStateException {
+    public String getHttpsOriginalRequestHostAndPort() throws IllegalStateException {
         if (!isHttps()) {
             throw new IllegalStateException("Request is not HTTPS. Cannot get original host and port on non-HTTPS request using this method.");
         }
 
         Attribute<String> hostnameAttr = ctx.attr(AttributeKey.<String>valueOf(ORIGINAL_HOST_ATTRIBUTE_NAME));
         return hostnameAttr.get();
+    }
+
+    /**
+     * Returns the full, absolute URL of the specified request for both HTTP and HTTPS URLs. The request may reflect
+     * modifications from this or other filters. This filter instance must be currently handling the specified request;
+     * otherwise the results are undefined.
+     *
+     * @param modifiedRequest a possibly-modified version of the request currently being processed
+     * @return the full URL of the request, including scheme, host, port, path, and query parameters
+     */
+    public String getFullUrl(HttpRequest modifiedRequest) {
+        // To get the full URL, we need to retrieve the Scheme, Host + Port, Path, and Query Params from the request.
+        // Scheme: the scheme (HTTP/HTTPS) may or may not be part of the request, and so must be generated based on the
+        //   type of connection.
+        // Host and Port: for HTTP requests, the host and port can be read from the request itself using the URI and/or
+        //   Host header. for HTTPS requests, the host and port are not available in the request. by using the
+        //   getHttpsRequestHostAndPort() helper method in HttpsAwareFiltersAdapter, we can capture the host and port for
+        //   HTTPS requests.
+        // Path + Query Params + Fragment: these elements are contained in the HTTP request
+        String url;
+        if (isHttps()) {
+            String hostAndPort = getHttpsRequestHostAndPort();
+            String path = BrowserMobHttpUtil.getPathFromRequest(modifiedRequest);
+            url = "https://" + hostAndPort + path;
+        } else {
+            String hostAndPort = BrowserMobHttpUtil.getHostAndPortFromRequest(modifiedRequest);
+            String path = BrowserMobHttpUtil.getPathFromRequest(modifiedRequest);
+            url = "http://" + hostAndPort + path;
+        }
+        return url;
+    }
+
+    /**
+     * Returns the full, absolute URL of the original request from the client for both HTTP and HTTPS URLs. The URL
+     * will not reflect modifications from this or other filters.
+     *
+     * @return the full URL of the original request, including scheme, host, port, path, and query parameters
+     */
+    public String getOriginalUrl() {
+        return getFullUrl(originalRequest);
+    }
+
+    /**
+     * Returns the host and port of the specified request for both HTTP and HTTPS requests.  The request may reflect
+     * modifications from this or other filters. This filter instance must be currently handling the specified request;
+     * otherwise the results are undefined.
+     *
+     * @param modifiedRequest a possibly-modified version of the request currently being processed
+     * @return host and port of the specified request
+     */
+    public String getHostAndPort(HttpRequest modifiedRequest) {
+        String serverHost;
+        if (isHttps()) {
+            HostAndPort hostAndPort = HostAndPort.fromString(getHttpsRequestHostAndPort());
+            serverHost = hostAndPort.getHostText();
+        } else {
+            serverHost = BrowserMobHttpUtil.getHostFromRequest(modifiedRequest);
+        }
+        return serverHost;
     }
 }

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RequestFilterAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RequestFilterAdapter.java
@@ -6,25 +6,19 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
 import org.littleshoot.proxy.HttpFilters;
-import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 
 /**
  * A filter adapter for {@link RequestFilter} implementations. Executes the filter when the {@link HttpFilters#clientToProxyRequest(HttpObject)}
  * method is invoked.
  */
-public class RequestFilterAdapter extends HttpFiltersAdapter {
+public class RequestFilterAdapter extends HttpsAwareFiltersAdapter {
     private final RequestFilter requestFilter;
 
     public RequestFilterAdapter(HttpRequest originalRequest, ChannelHandlerContext ctx, RequestFilter requestFilter) {
         super(originalRequest, ctx);
-
-        this.requestFilter = requestFilter;
-    }
-
-    public RequestFilterAdapter(HttpRequest originalRequest, RequestFilter requestFilter) {
-        super(originalRequest);
 
         this.requestFilter = requestFilter;
     }
@@ -45,7 +39,9 @@ public class RequestFilterAdapter extends HttpFiltersAdapter {
                 contents = null;
             }
 
-            HttpResponse response = requestFilter.filterRequest(httpRequest, contents, originalRequest);
+            HttpMessageInfo messageData = new HttpMessageInfo(originalRequest, ctx, isHttps(), getOriginalUrl());
+
+            HttpResponse response = requestFilter.filterRequest(httpRequest, contents, messageData);
             if (response != null) {
                 return response;
             }

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/ResponseFilterAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/ResponseFilterAdapter.java
@@ -6,25 +6,19 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
 import org.littleshoot.proxy.HttpFilters;
-import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
 
 /**
  * A filter adapter for {@link ResponseFilter} implementations. Executes the filter when the {@link HttpFilters#serverToProxyResponse(HttpObject)}
  * method is invoked.
  */
-public class ResponseFilterAdapter extends HttpFiltersAdapter {
+public class ResponseFilterAdapter extends HttpsAwareFiltersAdapter {
     private final ResponseFilter responseFilter;
 
     public ResponseFilterAdapter(HttpRequest originalRequest, ChannelHandlerContext ctx, ResponseFilter responseFilter) {
         super(originalRequest, ctx);
-
-        this.responseFilter = responseFilter;
-    }
-
-    public ResponseFilterAdapter(HttpRequest originalRequest, ResponseFilter responseFilter) {
-        super(originalRequest);
 
         this.responseFilter = responseFilter;
     }
@@ -45,7 +39,9 @@ public class ResponseFilterAdapter extends HttpFiltersAdapter {
                 contents = null;
             }
 
-            responseFilter.filterResponse(httpResponse, contents, originalRequest);
+            HttpMessageInfo messageData = new HttpMessageInfo(originalRequest, ctx, isHttps(), getOriginalUrl());
+
+            responseFilter.filterResponse(httpResponse, contents, messageData);
         }
 
         return super.serverToProxyResponse(httpObject);

--- a/browsermob-core/src/main/java/net/lightbody/bmp/filters/RequestFilter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/filters/RequestFilter.java
@@ -3,6 +3,7 @@ package net.lightbody.bmp.filters;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
 
 /**
  * A functional interface to simplify modification and manipulation of requests.
@@ -16,8 +17,8 @@ public interface RequestFilter {
      *
      * @param request The request object, including method, URI, headers, etc. Modifications to the request object will be reflected in the request sent to the server.
      * @param contents The request contents.
-     * @param originalRequest The original request from the client. Does not reflect any modifications from previous filters.
+     * @param messageInfo Additional information relating to the HTTP message.
      * @return if the return value is non-null, the proxy will suppress the request and send the specified response to the client immediately
      */
-    HttpResponse filterRequest(HttpRequest request, HttpMessageContents contents, HttpRequest originalRequest);
+    HttpResponse filterRequest(HttpRequest request, HttpMessageContents contents, HttpMessageInfo messageInfo);
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/filters/ResponseFilter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/filters/ResponseFilter.java
@@ -1,8 +1,8 @@
 package net.lightbody.bmp.filters;
 
-import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
 
 /**
  * A functional interface to simplify modification and manipulation of responses.
@@ -16,7 +16,7 @@ public interface ResponseFilter {
      *
      * @param response The response object, including URI, headers, status line, etc. Modifications to the response object will be reflected in the client response.
      * @param contents The response contents.
-     * @param originalRequest The original request from the client. Does not reflect any modifications from previous filters.
+     * @param messageInfo Additional information relating to the HTTP message.
      */
-    void filterResponse(HttpResponse response, HttpMessageContents contents, HttpRequest originalRequest);
+    void filterResponse(HttpResponse response, HttpMessageContents contents, HttpMessageInfo messageInfo);
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpMessageInfo.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpMessageInfo.java
@@ -1,0 +1,50 @@
+package net.lightbody.bmp.util;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpRequest;
+
+/**
+ * Encapsulates additional HTTP message data passed to request and response filters.
+ */
+public class HttpMessageInfo {
+    private final HttpRequest originalRequest;
+    private final ChannelHandlerContext channelHandlerContext;
+    private final boolean isHttps;
+    private final String originalUrl;
+
+    public HttpMessageInfo(HttpRequest originalRequest, ChannelHandlerContext channelHandlerContext, boolean isHttps, String originalUrl) {
+        this.originalRequest = originalRequest;
+        this.channelHandlerContext = channelHandlerContext;
+        this.isHttps = isHttps;
+        this.originalUrl = originalUrl;
+    }
+
+    /**
+     * The original request from the client. Does not reflect any modifications from previous filters.
+     */
+    public HttpRequest getOriginalRequest() {
+        return originalRequest;
+    }
+
+    /**
+     * The {@link ChannelHandlerContext} for this request's client connection.
+     */
+    public ChannelHandlerContext getChannelHandlerContext() {
+        return channelHandlerContext;
+    }
+
+    /**
+     * Returns true if this is an HTTPS message.
+     */
+    public boolean isHttps() {
+        return isHttps;
+    }
+
+    /**
+     * Returns the full, absolute URL of the original request from the client for both HTTP and HTTPS URLs. The URL
+     * will not reflect modifications from this or other filters.
+     */
+    public String getOriginalUrl() {
+        return originalUrl;
+    }
+}

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/exception/JavascriptCompilationException.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/exception/JavascriptCompilationException.java
@@ -1,9 +1,10 @@
 package net.lightbody.bmp.exception;
 
 import com.google.sitebricks.headless.Request;
+import net.lightbody.bmp.filters.JavascriptRequestResponseFilter;
 
 /**
- * Indicates that an error occurred when compiling javascript in {@link net.lightbody.bmp.proxy.bricks.ProxyResource.JavascriptRequestResponseFilter},
+ * Indicates that an error occurred when compiling javascript in {@link JavascriptRequestResponseFilter},
  * for use by {@link net.lightbody.bmp.proxy.bricks.ProxyResource#addRequestFilter(int, Request)}
  * or {@link net.lightbody.bmp.proxy.bricks.ProxyResource#addResponseFilter(int, Request)}.
  */

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/filters/JavascriptRequestResponseFilter.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/filters/JavascriptRequestResponseFilter.java
@@ -1,0 +1,91 @@
+package net.lightbody.bmp.filters;
+
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import net.lightbody.bmp.exception.JavascriptCompilationException;
+import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.script.Bindings;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ * Convenience class that executes arbitrary javascript code as a {@link RequestFilter} or {@link ResponseFilter}.
+ */
+public class JavascriptRequestResponseFilter implements RequestFilter, ResponseFilter {
+    private static final Logger log = LoggerFactory.getLogger(JavascriptRequestResponseFilter.class);
+
+    private static final ScriptEngine JAVASCRIPT_ENGINE = new ScriptEngineManager().getEngineByName("JavaScript");
+
+    private CompiledScript compiledRequestFilterScript;
+    private CompiledScript compiledResponseFilterScript;
+
+    public void setRequestFilterScript(String script) {
+        Compilable compilable = (Compilable) JAVASCRIPT_ENGINE;
+        try {
+            compiledRequestFilterScript = compilable.compile(script);
+        } catch (ScriptException e) {
+            throw new JavascriptCompilationException("Unable to compile javascript. Script in error:\n" + script, e);
+        }
+    }
+
+    public void setResponseFilterScript(String script) {
+        Compilable compilable = (Compilable) JAVASCRIPT_ENGINE;
+        try {
+            compiledResponseFilterScript = compilable.compile(script);
+        } catch (ScriptException e) {
+            throw new JavascriptCompilationException("Unable to compile javascript. Script in error:\n" + script, e);
+        }
+    }
+
+    @Override
+    public HttpResponse filterRequest(HttpRequest request, HttpMessageContents contents, HttpMessageInfo messageInfo) {
+        if (compiledRequestFilterScript == null) {
+            return null;
+        }
+
+        Bindings bindings = JAVASCRIPT_ENGINE.createBindings();
+        bindings.put("request", request);
+        bindings.put("contents", contents);
+        bindings.put("messageInfo", messageInfo);
+        bindings.put("log", log);
+
+        try {
+            Object retVal = compiledRequestFilterScript.eval(bindings);
+            // avoid implicit javascript returns
+            if (retVal instanceof HttpResponse) {
+                return (HttpResponse) retVal;
+            } else {
+                return null;
+            }
+        } catch (ScriptException e) {
+            log.error("Could not invoke filterRequest using supplied javascript", e);
+
+            return null;
+        }
+    }
+
+    @Override
+    public void filterResponse(HttpResponse response, HttpMessageContents contents, HttpMessageInfo messageInfo) {
+        if (compiledResponseFilterScript == null) {
+            return;
+        }
+
+        Bindings bindings = JAVASCRIPT_ENGINE.createBindings();
+        bindings.put("response", response);
+        bindings.put("contents", contents);
+        bindings.put("messageInfo", messageInfo);
+        bindings.put("log", log);
+        try {
+            compiledResponseFilterScript.eval(bindings);
+        } catch (ScriptException e) {
+            log.error("Could not invoke filterResponse using supplied javascript", e);
+        }
+    }
+}

--- a/browsermob-rest/src/test/groovy/net/lightbody/bmp/proxy/FilterTest.groovy
+++ b/browsermob-rest/src/test/groovy/net/lightbody/bmp/proxy/FilterTest.groovy
@@ -148,7 +148,7 @@ class FilterTest extends ProxyResourceTest {
 
         final String responseFilterJavaScript =
                 '''
-                contents.setTextContents(originalRequest.getUri());
+                contents.setTextContents(messageInfo.getOriginalRequest().getUri());
                 '''
         Request<String> mockRestAddRespFilterRequest = createMockRestRequestWithEntity(responseFilterJavaScript)
         proxyResource.addResponseFilter(proxyPort, mockRestAddRespFilterRequest)
@@ -168,7 +168,7 @@ class FilterTest extends ProxyResourceTest {
             uri.path = "/originalrequest"
 
             response.success = { resp, reader ->
-                assertThat("Javascript interceptor did not read originalRequest variable successfully", reader.text, endsWith("originalrequest"))
+                assertThat("Javascript interceptor did not read messageData.originalRequest variable successfully", reader.text, endsWith("originalrequest"))
             }
         }
     }


### PR DESCRIPTION
This PR replaces the originalRequest parameter on the RequestFilter and ResponseFilter with a new object, HttpMessageInfo. The new object provides access to the originalRequest, as well as an isHttps() method, the full URL (of the original request), and the client's ChannelHandlerContext.

The main motivator for this change was a recognition that we will want to expose additional data to the filters in the future. If we add them as interface parameters, the interface will become unmanageable, and every change will break all existing code. By placing these additional message parameters into an object, we can continue to add fields over time without breaking existing code.

Major thanks to @NozomiIto for bringing this issue to light in issue #238!