### PR TITLE
Added explicit netty dependency to browsermob-core-littleproxy

### DIFF
--- a/browsermob-core-littleproxy/pom.xml
+++ b/browsermob-core-littleproxy/pom.xml
@@ -216,6 +216,12 @@
             <artifactId>jzlib</artifactId>
         </dependency>
 
+        <!-- pull in a version of netty that is known to work with LP+BMP -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+
         <!-- Due to usage in LegacyProxyServer and BrowserMobProxyServer, this dependency needs to be given "provided" scope.
                      It is not used by the BMP LittleProxy implementation itself. -->
         <dependency>


### PR DESCRIPTION
This will force the netty version of projects that depend on BMP (unless the user explicitly overrides it, of course).