### PR TITLE
Blacklist & whitelist hanging response fix

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BlacklistFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BlacklistFilter.java
@@ -1,6 +1,7 @@
 package net.lightbody.bmp.filters;
 
-import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -36,7 +37,8 @@ public class BlacklistFilter extends HttpFiltersAdapter {
             for (BlacklistEntry entry : blacklistedUrls) {
                 if (entry.matches(httpRequest.getUri(), httpRequest.getMethod().name())) {
                     HttpResponseStatus status = HttpResponseStatus.valueOf(entry.getStatusCode());
-                    HttpResponse resp = new DefaultHttpResponse(httpRequest.getProtocolVersion(), status);
+                    HttpResponse resp = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(), status);
+                    HttpHeaders.setContentLength(resp, 0L);
 
                     return resp;
                 }

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
@@ -1,7 +1,8 @@
 package net.lightbody.bmp.filters;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -50,7 +51,9 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     public HttpResponse clientToProxyRequest(HttpObject httpObject) {
         if (proxyServer.isStopped()) {
             log.warn("Aborting request to {} because proxy is stopped", originalRequest.getUri());
-            return new DefaultHttpResponse(originalRequest.getProtocolVersion(), HttpResponseStatus.SERVICE_UNAVAILABLE);
+            HttpResponse abortedResponse = new DefaultFullHttpResponse(originalRequest.getProtocolVersion(), HttpResponseStatus.SERVICE_UNAVAILABLE);
+            HttpHeaders.setContentLength(abortedResponse, 0L);
+            return abortedResponse;
         }
 
         for (HttpFilters filter : filters) {

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/WhitelistFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/WhitelistFilter.java
@@ -1,6 +1,7 @@
 package net.lightbody.bmp.filters;
 
-import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -53,7 +54,8 @@ public class WhitelistFilter extends HttpFiltersAdapter {
 
             if (!urlWhitelisted) {
                 HttpResponseStatus status = HttpResponseStatus.valueOf(whitelistResponseCode);
-                HttpResponse resp = new DefaultHttpResponse(httpRequest.getProtocolVersion(), status);
+                HttpResponse resp = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(), status);
+                HttpHeaders.setContentLength(resp, 0L);
 
                 return resp;
             }

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/BlacklistTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/BlacklistTest.groovy
@@ -1,0 +1,60 @@
+package net.lightbody.bmp.proxy
+
+import net.lightbody.bmp.BrowserMobProxy
+import net.lightbody.bmp.BrowserMobProxyServer
+import net.lightbody.bmp.proxy.test.util.MockServerTest
+import net.lightbody.bmp.proxy.test.util.ProxyServerTest
+import net.lightbody.bmp.proxy.util.IOUtils
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpGet
+import org.junit.After
+import org.junit.Test
+
+import static org.hamcrest.Matchers.isEmptyOrNullString
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
+
+class BlacklistTest extends MockServerTest {
+    BrowserMobProxy proxy
+
+    @After
+    void tearDown() {
+        if (proxy?.started) {
+            proxy.abort()
+        }
+    }
+
+    @Test
+    void testBlacklistedRequestReturnsBlacklistStatusCode() {
+        proxy = new BrowserMobProxyServer();
+        proxy.start();
+        int proxyPort = proxy.getPort();
+
+        proxy.blacklistRequests("https?://www\\.blacklisted\\.domain/.*", 405)
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet("http://www.blacklisted.domain/someresource"))
+            assertEquals("Did not receive blacklisted status code in response", 405, response.getStatusLine().getStatusCode());
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
+            assertThat("Expected  blacklisted response to contain 0-length body", responseBody, isEmptyOrNullString())
+        };
+    }
+
+    @Test
+    void testNonWhitelistedRequestReturnsWhitelistStatusCode() {
+        proxy = new BrowserMobProxyServer();
+        proxy.start();
+        int proxyPort = proxy.getPort();
+
+        proxy.whitelistRequests(["https?://localhost/.*"], 405);
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet("http://www.someother.domain/someresource"))
+            assertEquals("Did not receive blacklisted status code in response", 405, response.getStatusLine().getStatusCode());
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
+            assertThat("Expected  blacklisted response to contain 0-length body", responseBody, isEmptyOrNullString())
+        };
+    }
+}

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
@@ -9,7 +9,6 @@ import net.lightbody.bmp.core.har.HarCookie
 import net.lightbody.bmp.core.har.HarEntry
 import net.lightbody.bmp.core.har.HarNameValuePair
 import net.lightbody.bmp.proxy.dns.AdvancedHostResolver
-import net.lightbody.bmp.proxy.dns.BasicHostResolver
 import net.lightbody.bmp.proxy.test.util.MockServerTest
 import net.lightbody.bmp.proxy.test.util.ProxyServerTest
 import net.lightbody.bmp.proxy.util.IOUtils
@@ -73,7 +72,7 @@ class NewHarTest extends MockServerTest {
                 .withStatusCode(200)
                 .withBody("success"));
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setHostNameResolver(mockResolver);
 
         proxy.start();
@@ -109,7 +108,7 @@ class NewHarTest extends MockServerTest {
                 .withBody("success")
                 .withCookie(new Cookie("mock-cookie", "mock value")))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setHarCaptureTypes([CaptureType.RESPONSE_COOKIES] as Set)
         proxy.start()
 
@@ -142,7 +141,7 @@ class NewHarTest extends MockServerTest {
                 .withBody("success")
                 .withHeader(new Header("Mock-Header", "mock value")))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setHarCaptureTypes([CaptureType.RESPONSE_HEADERS] as Set)
         proxy.start()
 
@@ -177,7 +176,7 @@ class NewHarTest extends MockServerTest {
                 .withBody("success")
                 .withHeader(new Header("Content-Type", "text/plain; charset=UTF-8")))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setHarCaptureTypes([CaptureType.RESPONSE_CONTENT] as Set)
         proxy.start()
 
@@ -210,7 +209,7 @@ class NewHarTest extends MockServerTest {
                 .withBody("success")
                 .withHeader(new Header("Content-Type", "text/plain; charset=UTF-8")))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setHarCaptureTypes([CaptureType.RESPONSE_CONTENT] as Set)
         proxy.start()
 
@@ -289,7 +288,7 @@ class NewHarTest extends MockServerTest {
                 .withBody("success")
                 .withHeader(new Header("Content-Type", "text/plain; charset=UTF-8")))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setHarCaptureTypes([CaptureType.RESPONSE_CONTENT] as Set)
         proxy.start()
 
@@ -340,7 +339,7 @@ class NewHarTest extends MockServerTest {
                 .withStatusCode(200)
                 .withBody("success"))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.start()
 
         proxy.newHar()
@@ -372,7 +371,7 @@ class NewHarTest extends MockServerTest {
                 .withStatusCode(200)
                 .withBody("success"))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.start()
 
         proxy.newHar()
@@ -409,7 +408,7 @@ class NewHarTest extends MockServerTest {
                 .withStatusCode(200)
                 .withBody("success"))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.start()
 
         proxy.newHar()
@@ -447,7 +446,7 @@ class NewHarTest extends MockServerTest {
                 .withStatusCode(200)
                 .withBody("success"))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.rewriteUrl("www.rewrittenurl.com:443", "localhost:${mockServerPort}")
         proxy.start()
 
@@ -493,7 +492,7 @@ class NewHarTest extends MockServerTest {
                 .withStatusCode(200)
                 .withBody("Response over HTTPS"))
 
-        BrowserMobProxy proxy = new BrowserMobProxyServer();
+        proxy = new BrowserMobProxyServer();
         proxy.setMitmDisabled(true);
         proxy.start()
 

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/WhitelistTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/WhitelistTest.groovy
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.isEmptyOrNullString
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
 
-class BlacklistTest extends MockServerTest {
+class WhitelistTest extends MockServerTest {
     BrowserMobProxy proxy
 
     @After
@@ -25,15 +25,15 @@ class BlacklistTest extends MockServerTest {
     }
 
     @Test
-    void testBlacklistedRequestReturnsBlacklistStatusCode() {
+    void testNonWhitelistedRequestReturnsWhitelistStatusCode() {
         proxy = new BrowserMobProxyServer();
         proxy.start();
         int proxyPort = proxy.getPort();
 
-        proxy.blacklistRequests("https?://www\\.blacklisted\\.domain/.*", 405)
+        proxy.whitelistRequests(["https?://localhost/.*"], 405);
 
         ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
-            CloseableHttpResponse response = it.execute(new HttpGet("http://www.blacklisted.domain/someresource"))
+            CloseableHttpResponse response = it.execute(new HttpGet("http://www.someother.domain/someresource"))
             assertEquals("Did not receive blacklisted status code in response", 405, response.getStatusLine().getStatusCode());
 
             String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());


### PR DESCRIPTION
This should fix an issue with blacklist and whitelist responses under LittleProxy. Since the BMP build of LittleProxy does not automatically close short-circuit responses from the black/whitelists, we need to explicitly set the Content Length so clients can detect the end of the message.