### PR TITLE
Added modified url to HttpMessageInfo

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
@@ -56,8 +56,20 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
         for (HttpFilters filter : filters) {
             HttpResponse filterResponse = filter.clientToProxyRequest(httpObject);
             if (filterResponse != null) {
+                // if we are short-circuiting the response to an HttpRequest, update ModifiedRequestAwareFilter instances
+                // with this (possibly) modified HttpRequest before returning the short-circuit response
+                if (httpObject instanceof HttpRequest) {
+                    updateFiltersWithModifiedResponse((HttpRequest) httpObject);
+                }
+
                 return filterResponse;
             }
+        }
+
+        // if this httpObject is the HTTP request, set the modified request object on all ModifiedRequestAwareFilter
+        // instances, so they have access to all modifications the request filters made while filtering
+        if (httpObject instanceof HttpRequest) {
+            updateFiltersWithModifiedResponse((HttpRequest) httpObject);
         }
 
         return null;
@@ -188,6 +200,21 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     public void proxyToServerConnectionQueued() {
         for (HttpFilters filter : filters) {
             filter.proxyToServerConnectionQueued();
+        }
+    }
+
+    /**
+     * Updates {@link ModifiedRequestAwareFilter} filters with the final, modified request after all request filters have
+     * processed the request.
+     *
+     * @param modifiedRequest the modified HttpRequest after all filters have finished processing it
+     */
+    private void updateFiltersWithModifiedResponse(HttpRequest modifiedRequest) {
+        for (HttpFilters filter : filters) {
+            if (filter instanceof ModifiedRequestAwareFilter) {
+                ModifiedRequestAwareFilter requestCaptureFilter = (ModifiedRequestAwareFilter) filter;
+                requestCaptureFilter.setModifiedHttpRequest(modifiedRequest);
+            }
         }
     }
 }

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/ModifiedRequestAwareFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/ModifiedRequestAwareFilter.java
@@ -1,0 +1,20 @@
+package net.lightbody.bmp.filters;
+
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+
+/**
+ * Indicates that a filter wishes to capture the final HttpRequest that is sent to the server, reflecting all
+ * modifications from request filters. {@link BrowserMobHttpFilterChain#clientToProxyRequest(HttpObject)} will invoke
+ * the {@link #setModifiedHttpRequest(HttpRequest)} method <b>after</b> all filters have processed the initial
+ * {@link HttpRequest} object.
+ */
+public interface ModifiedRequestAwareFilter {
+    /**
+     * Notifies implementing classes of the modified HttpRequest that will be sent to the server, reflecting all
+     * modifications from filters.
+     *
+     * @param modifiedHttpRequest the modified HttpRequest sent to the server
+     */
+    void setModifiedHttpRequest(HttpRequest modifiedHttpRequest);
+}

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RequestFilterAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RequestFilterAdapter.java
@@ -39,9 +39,9 @@ public class RequestFilterAdapter extends HttpsAwareFiltersAdapter {
                 contents = null;
             }
 
-            HttpMessageInfo messageData = new HttpMessageInfo(originalRequest, ctx, isHttps(), getOriginalUrl());
+            HttpMessageInfo messageInfo = new HttpMessageInfo(originalRequest, ctx, isHttps(), getFullUrl(httpRequest), getOriginalUrl());
 
-            HttpResponse response = requestFilter.filterRequest(httpRequest, contents, messageData);
+            HttpResponse response = requestFilter.filterRequest(httpRequest, contents, messageInfo);
             if (response != null) {
                 return response;
             }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpMessageInfo.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpMessageInfo.java
@@ -10,12 +10,14 @@ public class HttpMessageInfo {
     private final HttpRequest originalRequest;
     private final ChannelHandlerContext channelHandlerContext;
     private final boolean isHttps;
+    private final String url;
     private final String originalUrl;
 
-    public HttpMessageInfo(HttpRequest originalRequest, ChannelHandlerContext channelHandlerContext, boolean isHttps, String originalUrl) {
+    public HttpMessageInfo(HttpRequest originalRequest, ChannelHandlerContext channelHandlerContext, boolean isHttps, String url, String originalUrl) {
         this.originalRequest = originalRequest;
         this.channelHandlerContext = channelHandlerContext;
         this.isHttps = isHttps;
+        this.url = url;
         this.originalUrl = originalUrl;
     }
 
@@ -46,5 +48,14 @@ public class HttpMessageInfo {
      */
     public String getOriginalUrl() {
         return originalUrl;
+    }
+
+    /**
+     * Returns the full, absolute URL of this request from the client for both HTTP and HTTPS URLs. The URL will reflect
+     * modifications from filters. If this method is called while a request filter is processing, it will reflect any
+     * modifications to the URL from all previous filters.
+     */
+    public String getUrl() {
+        return url;
     }
 }


### PR DESCRIPTION
This PR exposes the actual URL, as modified by filters, to HttpMessageInfo. This should make adding multiple filters more convenient, since they will be able to see modifications to requests performed by previous filters.