### PR TITLE
Fixed blacklist and whitelist url pattern matching

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -1295,16 +1295,16 @@ public class BrowserMobProxyServer implements BrowserMobProxy, LegacyProxyServer
 
         addHttpFilterFactory(new HttpFiltersSourceAdapter() {
             @Override
-            public HttpFilters filterRequest(HttpRequest originalRequest) {
-                return new BlacklistFilter(originalRequest, getBlacklist());
+            public HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+                return new BlacklistFilter(originalRequest, ctx, getBlacklist());
             }
         });
 
         addHttpFilterFactory(new HttpFiltersSourceAdapter() {
             @Override
-            public HttpFilters filterRequest(HttpRequest originalRequest) {
+            public HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
                 Whitelist currentWhitelist = whitelist.get();
-                return new WhitelistFilter(originalRequest, isWhitelistEnabled(), currentWhitelist.getStatusCode(), currentWhitelist.getPatterns());
+                return new WhitelistFilter(originalRequest, ctx, isWhitelistEnabled(), currentWhitelist.getStatusCode(), currentWhitelist.getPatterns());
             }
         });
 

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BlacklistFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BlacklistFilter.java
@@ -1,5 +1,6 @@
 package net.lightbody.bmp.filters;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
@@ -7,7 +8,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import net.lightbody.bmp.proxy.BlacklistEntry;
-import org.littleshoot.proxy.HttpFiltersAdapter;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -16,11 +16,11 @@ import java.util.Collections;
  * Applies blacklist entries to this request. The filter does not make a defensive copy of the blacklist entries, so there is no guarantee
  * that the blacklist at the time of construction will contain the same values when the filter is actually invoked, if the entries are modified concurrently.
  */
-public class BlacklistFilter extends HttpFiltersAdapter {
+public class BlacklistFilter extends HttpsAwareFiltersAdapter {
     private final Collection<BlacklistEntry> blacklistedUrls;
 
-    public BlacklistFilter(HttpRequest originalRequest, Collection<BlacklistEntry> blacklistedUrls) {
-        super(originalRequest);
+    public BlacklistFilter(HttpRequest originalRequest, ChannelHandlerContext ctx, Collection<BlacklistEntry> blacklistedUrls) {
+        super(originalRequest, ctx);
 
         if (blacklistedUrls != null) {
             this.blacklistedUrls = blacklistedUrls;
@@ -34,8 +34,10 @@ public class BlacklistFilter extends HttpFiltersAdapter {
         if (httpObject instanceof HttpRequest) {
             HttpRequest httpRequest = (HttpRequest) httpObject;
 
+            String url = getFullUrl(httpRequest);
+
             for (BlacklistEntry entry : blacklistedUrls) {
-                if (entry.matches(httpRequest.getUri(), httpRequest.getMethod().name())) {
+                if (entry.matches(url, httpRequest.getMethod().name())) {
                     HttpResponseStatus status = HttpResponseStatus.valueOf(entry.getStatusCode());
                     HttpResponse resp = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(), status);
                     HttpHeaders.setContentLength(resp, 0L);

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
@@ -7,6 +7,7 @@ import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import net.lightbody.bmp.util.BrowserMobHttpUtil;
 import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.impl.ProxyUtils;
 
 /**
  * The HttpsAwareFiltersAdapter exposes the original host and the "real" host (after filter modifications) to filters for HTTPS
@@ -80,6 +81,11 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
      * @return the full URL of the request, including scheme, host, port, path, and query parameters
      */
     public String getFullUrl(HttpRequest modifiedRequest) {
+        // special case: for HTTPS requests, the full URL is scheme (https://) + the URI of this request
+        if (ProxyUtils.isCONNECT(modifiedRequest)) {
+            return "https://" + modifiedRequest.getUri();
+        }
+
         // To get the full URL, we need to retrieve the Scheme, Host + Port, Path, and Query Params from the request.
         // Scheme: the scheme (HTTP/HTTPS) may or may not be part of the request, and so must be generated based on the
         //   type of connection.

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/WhitelistFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/WhitelistFilter.java
@@ -1,12 +1,13 @@
 package net.lightbody.bmp.filters;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.impl.ProxyUtils;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -17,14 +18,14 @@ import java.util.regex.Pattern;
  * make a defensive copy of the whitelist URLs, so there is no guarantee that the whitelist URLs at the time of construction will contain the
  * same values when the filter is actually invoked, if the URL collection is modified concurrently.
  */
-public class WhitelistFilter extends HttpFiltersAdapter {
+public class WhitelistFilter extends HttpsAwareFiltersAdapter {
     private final boolean whitelistEnabled;
     private final int whitelistResponseCode;
     private final Collection<Pattern> whitelistUrls;
 
-    public WhitelistFilter(HttpRequest originalRequest, boolean whitelistEnabled,int whitelistResponseCode,
+    public WhitelistFilter(HttpRequest originalRequest, ChannelHandlerContext ctx, boolean whitelistEnabled,int whitelistResponseCode,
                            Collection<Pattern> whitelistUrls) {
-        super(originalRequest);
+        super(originalRequest, ctx);
 
         this.whitelistEnabled = whitelistEnabled;
         this.whitelistResponseCode = whitelistResponseCode;
@@ -43,10 +44,18 @@ public class WhitelistFilter extends HttpFiltersAdapter {
 
         if (httpObject instanceof HttpRequest) {
             HttpRequest httpRequest = (HttpRequest) httpObject;
+
+            // do not allow HTTP CONNECTs to be short-circuited
+            if (ProxyUtils.isCONNECT(httpRequest)) {
+                return null;
+            }
+
             boolean urlWhitelisted = false;
 
+            String url = getFullUrl(httpRequest);
+
             for (Pattern pattern : whitelistUrls) {
-                if (pattern.matcher(httpRequest.getUri()).matches()) {
+                if (pattern.matcher(url).matches()) {
                     urlWhitelisted = true;
                     break;
                 }

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/WhitelistTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/WhitelistTest.groovy
@@ -1,7 +1,12 @@
 package net.lightbody.bmp.proxy
 
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.HttpResponse
+import io.netty.handler.codec.http.HttpVersion
 import net.lightbody.bmp.BrowserMobProxy
 import net.lightbody.bmp.BrowserMobProxyServer
+import net.lightbody.bmp.filters.WhitelistFilter
 import net.lightbody.bmp.proxy.test.util.MockServerTest
 import net.lightbody.bmp.proxy.test.util.ProxyServerTest
 import net.lightbody.bmp.proxy.util.IOUtils
@@ -9,10 +14,16 @@ import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.junit.After
 import org.junit.Test
+import org.mockserver.matchers.Times
 
 import static org.hamcrest.Matchers.isEmptyOrNullString
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertThat
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+import static org.mockserver.model.HttpRequest.request
+import static org.mockserver.model.HttpResponse.response
 
 class WhitelistTest extends MockServerTest {
     BrowserMobProxy proxy
@@ -25,19 +36,186 @@ class WhitelistTest extends MockServerTest {
     }
 
     @Test
-    void testNonWhitelistedRequestReturnsWhitelistStatusCode() {
-        proxy = new BrowserMobProxyServer();
-        proxy.start();
-        int proxyPort = proxy.getPort();
+    void testWhitelistCannotShortCircuitCONNECT() {
+        HttpRequest request = mock(HttpRequest.class)
+        when(request.getMethod()).thenReturn(HttpMethod.CONNECT)
+        when(request.getUri()).thenReturn('somedomain.com:443')
+        when(request.getProtocolVersion()).thenReturn(HttpVersion.HTTP_1_1)
 
-        proxy.whitelistRequests(["https?://localhost/.*"], 405);
+        // create a whitelist filter that whitelists no requests (i.e., all requests should return the specified HTTP 500 status code)
+        WhitelistFilter filter = new WhitelistFilter(request, null, true, 500, [])
+        HttpResponse response = filter.clientToProxyRequest(request)
+
+        assertNull("Whitelist short-circuited HTTP CONNECT. Expected all HTTP CONNECTs to be whitelisted.", response)
+    }
+
+    @Test
+    void testNonWhitelistedHttpRequestReturnsWhitelistStatusCode() {
+        proxy = new BrowserMobProxyServer()
+        proxy.start()
+        int proxyPort = proxy.getPort()
+
+        proxy.whitelistRequests(["http://localhost/.*"], 500)
 
         ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
             CloseableHttpResponse response = it.execute(new HttpGet("http://www.someother.domain/someresource"))
-            assertEquals("Did not receive blacklisted status code in response", 405, response.getStatusLine().getStatusCode());
+            assertEquals("Did not receive whitelist status code in response", 500, response.getStatusLine().getStatusCode())
 
-            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
-            assertThat("Expected  blacklisted response to contain 0-length body", responseBody, isEmptyOrNullString())
-        };
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent())
+            assertThat("Expected whitelist response to contain 0-length body", responseBody, isEmptyOrNullString())
+        }
+    }
+
+    @Test
+    void testNonWhitelistedHttpsRequestReturnsWhitelistStatusCode() {
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/nonwhitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("should never be returned"))
+
+        proxy = new BrowserMobProxyServer()
+        proxy.start()
+        int proxyPort = proxy.getPort()
+
+        proxy.whitelistRequests(["https://some-other-domain/.*"], 500)
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet("https://localhost:${mockServerPort}/nonwhitelistedresource"))
+            assertEquals("Did not receive whitelist status code in response", 500, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent())
+            assertThat("Expected whitelist response to contain 0-length body", responseBody, isEmptyOrNullString())
+        }
+    }
+
+    @Test
+    void testWhitelistedHttpRequestNotShortCircuited() {
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/whitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("whitelisted"))
+
+        proxy = new BrowserMobProxyServer()
+        proxy.start()
+        int proxyPort = proxy.getPort()
+
+        proxy.whitelistRequests(["http://localhost:${mockServerPort}/.*".toString()], 500)
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet("http://localhost:${mockServerPort}/whitelistedresource"))
+            assertEquals("Did not receive expected response from mock server for whitelisted url", 200, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent())
+            assertEquals("Did not receive expected response body from mock server for whitelisted url", "whitelisted", responseBody)
+        }
+    }
+
+    @Test
+    void testWhitelistedHttpsRequestNotShortCircuited() {
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/whitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("whitelisted"))
+
+        proxy = new BrowserMobProxyServer()
+        proxy.start()
+        int proxyPort = proxy.getPort()
+
+        proxy.whitelistRequests(["https://localhost:${mockServerPort}/.*".toString()], 500)
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet("https://localhost:${mockServerPort}/whitelistedresource"))
+            assertEquals("Did not receive expected response from mock server for whitelisted url", 200, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent())
+            assertEquals("Did not receive expected response body from mock server for whitelisted url", "whitelisted", responseBody)
+        }
+    }
+
+    @Test
+    void testCanWhitelistSpecificHttpResource() {
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/whitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("whitelisted"))
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/nonwhitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("should never be returned"))
+
+        proxy = new BrowserMobProxyServer()
+        proxy.start()
+        int proxyPort = proxy.getPort()
+
+        proxy.whitelistRequests(["http://localhost:${mockServerPort}/whitelistedresource".toString()], 500)
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse nonWhitelistedResponse = it.execute(new HttpGet("http://localhost:${mockServerPort}/nonwhitelistedresource"))
+            assertEquals("Did not receive whitelist status code in response", 500, nonWhitelistedResponse.getStatusLine().getStatusCode())
+
+            String nonWhitelistedResponseBody = IOUtils.toStringAndClose(nonWhitelistedResponse.getEntity().getContent())
+            assertThat("Expected whitelist response to contain 0-length body", nonWhitelistedResponseBody, isEmptyOrNullString())
+
+            CloseableHttpResponse whitelistedResponse = it.execute(new HttpGet("http://localhost:${mockServerPort}/whitelistedresource"))
+            assertEquals("Did not receive expected response from mock server for whitelisted url", 200, whitelistedResponse.getStatusLine().getStatusCode())
+
+            String whitelistedResponseBody = IOUtils.toStringAndClose(whitelistedResponse.getEntity().getContent())
+            assertEquals("Did not receive expected response body from mock server for whitelisted url", "whitelisted", whitelistedResponseBody)
+        }
+    }
+
+    @Test
+    void testCanWhitelistSpecificHttpsResource() {
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/whitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("whitelisted"))
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/nonwhitelistedresource"),
+                Times.unlimited())
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("should never be returned"))
+
+        proxy = new BrowserMobProxyServer()
+        proxy.start()
+        int proxyPort = proxy.getPort()
+
+        proxy.whitelistRequests(["https://localhost:${mockServerPort}/whitelistedresource".toString()], 500)
+
+        ProxyServerTest.getNewHttpClient(proxyPort).withCloseable {
+            CloseableHttpResponse nonWhitelistedResponse = it.execute(new HttpGet("https://localhost:${mockServerPort}/nonwhitelistedresource"))
+            assertEquals("Did not receive whitelist status code in response", 500, nonWhitelistedResponse.getStatusLine().getStatusCode())
+
+            String nonWhitelistedResponseBody = IOUtils.toStringAndClose(nonWhitelistedResponse.getEntity().getContent())
+            assertThat("Expected whitelist response to contain 0-length body", nonWhitelistedResponseBody, isEmptyOrNullString())
+
+            CloseableHttpResponse whitelistedResponse = it.execute(new HttpGet("https://localhost:${mockServerPort}/whitelistedresource"))
+            assertEquals("Did not receive expected response from mock server for whitelisted url", 200, whitelistedResponse.getStatusLine().getStatusCode())
+
+            String whitelistedResponseBody = IOUtils.toStringAndClose(whitelistedResponse.getEntity().getContent())
+            assertEquals("Did not receive expected response body from mock server for whitelisted url", "whitelisted", whitelistedResponseBody)
+        }
     }
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -343,6 +343,10 @@ public interface BrowserMobProxy {
      * Adds a URL-matching regular expression to the blacklist. Requests that match a blacklisted URL will return the specified HTTP
      * statusCode for all HTTP methods. If there are existing patterns on the blacklist, the urlPattern will be evaluated last,
      * after the URL is checked against all other blacklist entries.
+     * <p/>
+     * The urlPattern matches the full URL of the request, including scheme, host, and port, path, and query parameters
+     * for both HTTP and HTTPS requests. For example, to blacklist both HTTP and HTTPS requests to www.google.com,
+     * use a urlPattern of "https?://www\\.google\\.com/.*".
      *
      * @param urlPattern URL-matching regular expression to blacklist
      * @param statusCode HTTP status code to return
@@ -353,7 +357,9 @@ public interface BrowserMobProxy {
      * Adds a URL-matching regular expression to the blacklist. Requests that match a blacklisted URL will return the specified HTTP
      * statusCode only when the request's HTTP method (GET, POST, PUT, etc.) matches the specified httpMethodPattern regular expression.
      * If there are existing patterns on the blacklist, the urlPattern will be evaluated last, after the URL is checked against all
-     * other blacklist entries
+     * other blacklist entries.
+     * <p/>
+     * See {@link #blacklistRequests(String, int)} for details on the URL the urlPattern will match.
      *
      * @param urlPattern URL-matching regular expression to blacklist
      * @param statusCode HTTP status code to return
@@ -384,6 +390,12 @@ public interface BrowserMobProxy {
 
     /**
      * Whitelists URLs matching the specified regular expression patterns. Replaces any existing whitelist.
+     * The urlPattern matches the full URL of the request, including scheme, host, and port, path, and query parameters
+     * for both HTTP and HTTPS requests. For example, to whitelist both HTTP and HTTPS requests to www.google.com, use a urlPattern
+     * of "https?://www\\.google\\.com/.*".
+     * <p/>
+     * <b>Note:</b> All HTTP CONNECT requests are automatically whitelisted and cannot be short-circuited using the
+     * whitelist response code.
      *
      * @param urlPatterns URL-matching regular expressions to whitelist; null or an empty collection will enable an empty whitelist
      * @param statusCode HTTP status code to return to clients when a URL matches a pattern


### PR DESCRIPTION
This PR makes whitelist and blacklist pattern matching consistent across HTTP and HTTPS calls. Blacklist and whitelist entries will match the entire URL, including scheme, host, and port.

All HTTP CONNECTs are now automatically whitelisted and cannot be short-circuited using the whitelist response code.