### PR TITLE
Not aborting requests when filter in filter chain throws exception

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
@@ -57,15 +57,19 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
         }
 
         for (HttpFilters filter : filters) {
-            HttpResponse filterResponse = filter.clientToProxyRequest(httpObject);
-            if (filterResponse != null) {
-                // if we are short-circuiting the response to an HttpRequest, update ModifiedRequestAwareFilter instances
-                // with this (possibly) modified HttpRequest before returning the short-circuit response
-                if (httpObject instanceof HttpRequest) {
-                    updateFiltersWithModifiedResponse((HttpRequest) httpObject);
-                }
+            try {
+                HttpResponse filterResponse = filter.clientToProxyRequest(httpObject);
+                if (filterResponse != null) {
+                    // if we are short-circuiting the response to an HttpRequest, update ModifiedRequestAwareFilter instances
+                    // with this (possibly) modified HttpRequest before returning the short-circuit response
+                    if (httpObject instanceof HttpRequest) {
+                        updateFiltersWithModifiedResponse((HttpRequest) httpObject);
+                    }
 
-                return filterResponse;
+                    return filterResponse;
+                }
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
             }
         }
 
@@ -81,9 +85,13 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     @Override
     public HttpResponse proxyToServerRequest(HttpObject httpObject) {
         for (HttpFilters filter : filters) {
-            HttpResponse filterResponse = filter.proxyToServerRequest(httpObject);
-            if (filterResponse != null) {
-                return filterResponse;
+            try {
+                HttpResponse filterResponse = filter.proxyToServerRequest(httpObject);
+                if (filterResponse != null) {
+                    return filterResponse;
+                }
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
             }
         }
 
@@ -93,7 +101,11 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     @Override
     public void proxyToServerRequestSending() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerRequestSending();
+            try {
+                filter.proxyToServerRequestSending();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
@@ -103,9 +115,13 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
         HttpObject processedHttpObject = httpObject;
 
         for (HttpFilters filter : filters) {
-            processedHttpObject = filter.serverToProxyResponse(processedHttpObject);
-            if (processedHttpObject == null) {
-                return null;
+            try {
+                processedHttpObject = filter.serverToProxyResponse(processedHttpObject);
+                if (processedHttpObject == null) {
+                    return null;
+                }
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
             }
         }
 
@@ -115,14 +131,22 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     @Override
     public void serverToProxyResponseTimedOut() {
         for (HttpFilters filter : filters) {
-            filter.serverToProxyResponseTimedOut();
+            try {
+                filter.serverToProxyResponseTimedOut();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void serverToProxyResponseReceiving() {
         for (HttpFilters filter : filters) {
-            filter.serverToProxyResponseReceiving();
+            try {
+                filter.serverToProxyResponseReceiving();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
@@ -132,10 +156,14 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
         String newServerHostAndPort = resolvingServerHostAndPort;
 
         for (HttpFilters filter : filters) {
-            InetSocketAddress filterResult = filter.proxyToServerResolutionStarted(newServerHostAndPort);
-            if (filterResult != null) {
-                overrideAddress = filterResult;
-                newServerHostAndPort = filterResult.getHostString() + ":" + filterResult.getPort();
+            try {
+                InetSocketAddress filterResult = filter.proxyToServerResolutionStarted(newServerHostAndPort);
+                if (filterResult != null) {
+                    overrideAddress = filterResult;
+                    newServerHostAndPort = filterResult.getHostString() + ":" + filterResult.getPort();
+                }
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
             }
         }
 
@@ -145,14 +173,22 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     @Override
     public void proxyToServerResolutionFailed(String hostAndPort) {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerResolutionFailed(hostAndPort);
+            try {
+                filter.proxyToServerResolutionFailed(hostAndPort);
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void proxyToServerResolutionSucceeded(String serverHostAndPort, InetSocketAddress resolvedRemoteAddress) {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerResolutionSucceeded(serverHostAndPort, resolvedRemoteAddress);
+            try {
+                filter.proxyToServerResolutionSucceeded(serverHostAndPort, resolvedRemoteAddress);
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
 
         super.proxyToServerResolutionSucceeded(serverHostAndPort, resolvedRemoteAddress);
@@ -161,42 +197,66 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     @Override
     public void proxyToServerConnectionStarted() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerConnectionStarted();
+            try {
+                filter.proxyToServerConnectionStarted();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void proxyToServerConnectionSSLHandshakeStarted() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerConnectionSSLHandshakeStarted();
+            try {
+                filter.proxyToServerConnectionSSLHandshakeStarted();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void proxyToServerConnectionFailed() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerConnectionFailed();
+            try {
+                filter.proxyToServerConnectionFailed();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void proxyToServerConnectionSucceeded() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerConnectionSucceeded();
+            try {
+                filter.proxyToServerConnectionSucceeded();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void proxyToServerRequestSent() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerRequestSent();
+            try {
+                filter.proxyToServerRequestSent();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
     @Override
     public void serverToProxyResponseReceived() {
         for (HttpFilters filter : filters) {
-            filter.serverToProxyResponseReceived();
+            try {
+                filter.serverToProxyResponseReceived();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
@@ -204,9 +264,13 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     public HttpObject proxyToClientResponse(HttpObject httpObject) {
         HttpObject processedHttpObject = httpObject;
         for (HttpFilters filter : filters) {
-            processedHttpObject = filter.proxyToClientResponse(processedHttpObject);
-            if (processedHttpObject == null) {
-                return null;
+            try {
+                processedHttpObject = filter.proxyToClientResponse(processedHttpObject);
+                if (processedHttpObject == null) {
+                    return null;
+                }
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
             }
         }
 
@@ -216,7 +280,11 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
     @Override
     public void proxyToServerConnectionQueued() {
         for (HttpFilters filter : filters) {
-            filter.proxyToServerConnectionQueued();
+            try {
+                filter.proxyToServerConnectionQueued();
+            } catch (RuntimeException e) {
+                log.warn("Filter in filter chain threw exception. Filter method may have been aborted.", e);
+            }
         }
     }
 
@@ -230,7 +298,11 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
         for (HttpFilters filter : filters) {
             if (filter instanceof ModifiedRequestAwareFilter) {
                 ModifiedRequestAwareFilter requestCaptureFilter = (ModifiedRequestAwareFilter) filter;
-                requestCaptureFilter.setModifiedHttpRequest(modifiedRequest);
+                try {
+                    requestCaptureFilter.setModifiedHttpRequest(modifiedRequest);
+                } catch (RuntimeException e) {
+                    log.warn("ModifiedRequestAwareFilter in filter chain threw exception while setting modified HTTP request.", e);
+                }
             }
         }
     }

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/FilterChainTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/FilterChainTest.groovy
@@ -1,0 +1,320 @@
+package net.lightbody.bmp.proxy
+
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http.HttpObject
+import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.HttpResponse
+import net.lightbody.bmp.BrowserMobProxy
+import net.lightbody.bmp.BrowserMobProxyServer
+import net.lightbody.bmp.proxy.test.util.MockServerTest
+import net.lightbody.bmp.proxy.test.util.ProxyServerTest
+import net.lightbody.bmp.proxy.util.IOUtils
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpGet
+import org.junit.After
+import org.junit.Test
+import org.littleshoot.proxy.HttpFilters
+import org.littleshoot.proxy.HttpFiltersAdapter
+import org.littleshoot.proxy.HttpFiltersSourceAdapter
+import org.mockserver.matchers.Times
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+import static org.mockserver.model.HttpRequest.request
+import static org.mockserver.model.HttpResponse.response
+
+/**
+ * Tests for the {@link net.lightbody.bmp.filters.BrowserMobHttpFilterChain}.
+ */
+class FilterChainTest extends MockServerTest {
+    private BrowserMobProxy proxy
+
+    @After
+    void tearDown() {
+        if (proxy?.started) {
+            proxy.abort()
+        }
+    }
+
+    @Test
+    void testFilterExceptionDoesNotAbortRequest() {
+        // tests that an exception in one filter does not prevent the request from completing
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/testfilterexceptionpreservesrequest"),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"));
+
+        proxy = new BrowserMobProxyServer();
+
+        proxy.addHttpFilterFactory(new HttpFiltersSourceAdapter() {
+            @Override
+            HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+                return new ThrowExceptionFilter()
+            }
+        })
+
+        proxy.start()
+
+        String requestUrl = "http://localhost:${mockServerPort}/testfilterexceptionpreservesrequest"
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet(requestUrl))
+            assertEquals("Did not receive HTTP 200 from mock server", 200, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+    }
+
+    @Test
+    void testFilterExceptionDoesNotAbortFilterChain() {
+        // tests that an exception in the first filter in a filter chain does not prevent subsequent filters from being invoked
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/testfilterexceptionpreserveschain"),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"));
+
+        proxy = new BrowserMobProxyServer();
+
+        proxy.addHttpFilterFactory(new HttpFiltersSourceAdapter() {
+            @Override
+            HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+                return new ThrowExceptionFilter()
+            }
+        })
+
+        // rather than test every filter method (which would be verbose), test three filter methods that are representative
+        // of the entire request-response lifecycle are still fired
+        final AtomicBoolean clientToProxyRequest = new AtomicBoolean()
+        final AtomicBoolean serverToProxyResponse = new AtomicBoolean()
+        final AtomicBoolean proxyToClientResponse = new AtomicBoolean()
+
+        proxy.addHttpFilterFactory(new HttpFiltersSourceAdapter() {
+            @Override
+            HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+                return new HttpFiltersAdapter(originalRequest) {
+                    @Override
+                    HttpResponse clientToProxyRequest(HttpObject httpObject) {
+                        clientToProxyRequest.set(true)
+                        return super.clientToProxyRequest(httpObject)
+                    }
+
+                    @Override
+                    HttpObject serverToProxyResponse(HttpObject httpObject) {
+                        serverToProxyResponse.set(true)
+                        return super.serverToProxyResponse(httpObject)
+                    }
+
+                    @Override
+                    HttpObject proxyToClientResponse(HttpObject httpObject) {
+                        proxyToClientResponse.set(true)
+                        return super.proxyToClientResponse(httpObject)
+                    }
+                }
+            }
+        })
+
+        proxy.start()
+
+        String requestUrl = "http://localhost:${mockServerPort}/testfilterexceptionpreserveschain"
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet(requestUrl))
+            assertEquals("Did not receive HTTP 200 from mock server", 200, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+
+        assertTrue("Expected second filter method to be invoked after first filter threw exception", clientToProxyRequest.get())
+        assertTrue("Expected second filter method to be invoked after first filter threw exception", serverToProxyResponse.get())
+        assertTrue("Expected second filter method to be invoked after first filter threw exception", proxyToClientResponse.get())
+    }
+
+    @Test
+    void testRequestResponseFilterExceptionsDoNotAbortRequest() {
+        // tests that exceptions thrown by the RequestFilter and ResponseFilter do not abort the request
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/testrequestresponsefilterpreservesrequest"),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"));
+
+        proxy = new BrowserMobProxyServer();
+
+        proxy.addRequestFilter({ a, b, c ->
+            throw new RuntimeException("Throwing exception from RequestFilter")
+        })
+
+        proxy.addResponseFilter({ a, b, c ->
+            throw new RuntimeException("Throwing exception from ResponseFilter")
+        })
+
+        proxy.start()
+
+        String requestUrl = "http://localhost:${mockServerPort}/testrequestresponsefilterpreservesrequest"
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet(requestUrl))
+            assertEquals("Did not receive HTTP 200 from mock server", 200, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+    }
+
+    @Test
+    void testRequestResponseFilterExceptionsDoNotAbortFilterChain() {
+        // tests that exceptions thrown by the RequestFilter and ResponseFilter do not prevent subsequent filters from being invoked
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/testrequestresponsefilterpreserveschain"),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"));
+
+        proxy = new BrowserMobProxyServer();
+
+        final AtomicBoolean secondRequestFilterInvoked = new AtomicBoolean()
+        final AtomicBoolean secondResponseFilterInvoked = new AtomicBoolean()
+
+        proxy.addRequestFilter({ a, b, c ->
+            // actually the second filter invoked, since the following addRequestFilter will place itself at the front of the filter chain
+            secondRequestFilterInvoked.set(true)
+        })
+
+        proxy.addRequestFilter({ a, b, c ->
+            assertFalse("Did not expect second request filter to be invoked yet", secondRequestFilterInvoked.get())
+            throw new RuntimeException("Throwing exception from RequestFilter")
+        })
+
+        proxy.addResponseFilter({ a, b, c ->
+            assertFalse("Did not expect second response filter to be invoked yet", secondResponseFilterInvoked.get())
+            throw new RuntimeException("Throwing exception from ResponseFilter")
+        })
+
+        proxy.addResponseFilter({ a, b, c ->
+            secondResponseFilterInvoked.set(true)
+        })
+
+        proxy.start()
+
+        String requestUrl = "http://localhost:${mockServerPort}/testrequestresponsefilterpreserveschain"
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet(requestUrl))
+            assertEquals("Did not receive HTTP 200 from mock server", 200, response.getStatusLine().getStatusCode())
+
+            String responseBody = IOUtils.toStringAndClose(response.getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+
+        assertTrue("Expected second request filter to be invoked", secondRequestFilterInvoked.get())
+        assertTrue("Expected second response filter to be invoked", secondResponseFilterInvoked.get())
+    }
+
+    /**
+     * An HttpFilters implementation that throws an exception from every filter method.
+     */
+    static class ThrowExceptionFilter implements HttpFilters {
+
+        @Override
+        HttpResponse clientToProxyRequest(HttpObject httpObject) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        HttpResponse proxyToServerRequest(HttpObject httpObject) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerRequestSending() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerRequestSent() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        HttpObject serverToProxyResponse(HttpObject httpObject) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void serverToProxyResponseTimedOut() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void serverToProxyResponseReceiving() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void serverToProxyResponseReceived() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        HttpObject proxyToClientResponse(HttpObject httpObject) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerConnectionQueued() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        InetSocketAddress proxyToServerResolutionStarted(String resolvingServerHostAndPort) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerResolutionFailed(String hostAndPort) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerResolutionSucceeded(String serverHostAndPort, InetSocketAddress resolvedRemoteAddress) {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerConnectionStarted() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerConnectionSSLHandshakeStarted() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerConnectionFailed() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+
+        @Override
+        void proxyToServerConnectionSucceeded() {
+            throw new RuntimeException("Throwing exception from filter")
+        }
+    }
+}


### PR DESCRIPTION
This PR suppresses (but logs) exceptions thrown from filters in the filter chain, to prevent requests from being aborted.