### PR TITLE
Add HAR error capture for HTTPS requests

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BrowserMobHttpFilterChain.java
@@ -40,7 +40,11 @@ public class BrowserMobHttpFilterChain extends HttpFiltersAdapter {
             // instantiate all HttpFilters using the proxy's filter factories
             for (HttpFiltersSource filterFactory : proxyServer.getFilterFactories()) {
                 HttpFilters filter = filterFactory.filterRequest(originalRequest, ctx);
-                filters.add(filter);
+                // allow filter factories to avoid adding a filter on a per-request basis by returning a null
+                // HttpFilters instance
+                if (filter != null) {
+                    filters.add(filter);
+                }
             }
         } else {
             filters = Collections.emptyList();

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsConnectHarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsConnectHarCaptureFilter.java
@@ -1,0 +1,313 @@
+package net.lightbody.bmp.filters;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import net.lightbody.bmp.core.har.Har;
+import net.lightbody.bmp.core.har.HarEntry;
+import net.lightbody.bmp.core.har.HarRequest;
+import net.lightbody.bmp.core.har.HarResponse;
+import net.lightbody.bmp.core.har.HarTimings;
+import net.lightbody.bmp.filters.util.HarCaptureUtil;
+import org.littleshoot.proxy.impl.ProxyUtils;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This filter captures HAR data for HTTP CONNECT requests. CONNECTs are "meta" requests that must be made before HTTPS
+ * requests, but are not populated as separate requests in the HAR. Most information from HTTP CONNECTs (such as SSL
+ * handshake time, dns resolution time, etc.) is populated in the HAR entry for the first "true" request following the
+ * CONNECT. This filter captures the timing-related information and makes it available to subsequent filters through
+ * static methods. This filter also handles HTTP CONNECT errors and creates HAR entries for those errors, since there
+ * would otherwise not be any record in the HAR of the error (if the CONNECT fails, there will be no subsequent "real"
+ * request in which to record the error).
+ *
+ * TODO: refactor other HTTP CONNECT-specific logic out of HarCaptureFilter
+ */
+public class HttpsConnectHarCaptureFilter extends HttpsAwareFiltersAdapter {
+    /**
+     * The currently active HAR at the time the current request is received.
+     */
+    private final Har har;
+
+    /**
+     * The currently active page ref at the time the current request is received.
+     */
+    private final String currentPageRef;
+
+    /**
+     * The time this CONNECT began. Used to populate the HAR entry in case of failure.
+     */
+    private volatile Date requestStartTime;
+
+    /**
+     * Populated by proxyToServerResolutionStarted when DNS resolution starts. If any previous filters already resolved the address, their resolution time
+     * will not be included in this time. See {@link HarCaptureFilter#dnsResolutionStartedNanos}.
+     */
+    private volatile long dnsResolutionStartedNanos;
+
+    private volatile long dnsResolutionFinishedNanos;
+
+    private volatile long connectionQueuedNanos;
+    private volatile long connectionStartedNanos;
+    private volatile long connectionSucceededTimeNanos;
+    private volatile long sendStartedNanos;
+    private volatile long sendFinishedNanos;
+
+    private volatile long responseReceiveStartedNanos;
+    private volatile long sslHandshakeStartedNanos;
+
+    public HttpsConnectHarCaptureFilter(HttpRequest originalRequest, ChannelHandlerContext ctx, Har har, String currentPageRef) {
+        super(originalRequest, ctx);
+
+        boolean httpConnect = ProxyUtils.isCONNECT(originalRequest);
+
+        if (!httpConnect) {
+            this.har = null;
+            this.currentPageRef = null;
+        } else {
+            this.har = har;
+            this.currentPageRef = currentPageRef;
+        }
+    }
+
+    @Override
+    public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+        if (har == null) {
+            return null;
+        }
+
+        if (httpObject instanceof HttpRequest) {
+            // store the CONNECT start time in case of failure, so we can populate the HarEntry with it
+            requestStartTime = new Date();
+        }
+
+        return null;
+    }
+
+    @Override
+    public void proxyToServerResolutionFailed(String hostAndPort) {
+        if (har == null) {
+            return;
+        }
+
+        // since this is a CONNECT, which is not handled by the HarCaptureFilter, we need to create and populate the
+        // entire HarEntry and add it to this har.
+        HarEntry harEntry = createHarEntryForFailedCONNECT(HarCaptureUtil.getResolutionFailedErrorMessage(hostAndPort));
+        har.getLog().addEntry(harEntry);
+
+        // record the amount of time we attempted to resolve the hostname in the HarTimings object
+        if (dnsResolutionStartedNanos > 0L) {
+            harEntry.getTimings().setDns(System.nanoTime() - dnsResolutionStartedNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void proxyToServerConnectionFailed() {
+        if (har == null) {
+            return;
+        }
+
+        // since this is a CONNECT, which is not handled by the HarCaptureFilter, we need to create and populate the
+        // entire HarEntry and add it to this har.
+        HarEntry harEntry = createHarEntryForFailedCONNECT(HarCaptureUtil.getConnectionFailedErrorMessage());
+        har.getLog().addEntry(harEntry);
+
+        // record the amount of time we attempted to connect in the HarTimings object
+        if (connectionStartedNanos > 0L) {
+            harEntry.getTimings().setConnect(System.nanoTime() - connectionStartedNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void proxyToServerConnectionSucceeded() {
+        if (har == null) {
+            return;
+        }
+
+        this.connectionSucceededTimeNanos = System.nanoTime();
+    }
+
+    @Override
+    public void proxyToServerConnectionSSLHandshakeStarted() {
+        if (har == null) {
+            return;
+        }
+
+        this.sslHandshakeStartedNanos = System.nanoTime();
+    }
+
+    @Override
+    public void serverToProxyResponseTimedOut() {
+        if (har == null) {
+            return;
+        }
+
+        HarEntry harEntry = createHarEntryForFailedCONNECT(HarCaptureUtil.getResponseTimedOutErrorMessage());
+        har.getLog().addEntry(harEntry);
+
+        // include this timeout time in the HarTimings object
+        long timeoutTimestampNanos = System.nanoTime();
+
+        // if the proxy started to send the request but has not yet finished, we are currently "sending"
+        if (sendStartedNanos > 0L && sendFinishedNanos == 0L) {
+            harEntry.getTimings().setSend(timeoutTimestampNanos - sendStartedNanos, TimeUnit.NANOSECONDS);
+        }
+        // if the entire request was sent but the proxy has not begun receiving the response, we are currently "waiting"
+        else if (sendFinishedNanos > 0L && responseReceiveStartedNanos == 0L) {
+            harEntry.getTimings().setWait(timeoutTimestampNanos - sendFinishedNanos, TimeUnit.NANOSECONDS);
+        }
+        // if the proxy has already begun to receive the response, we are currenting "receiving"
+        else if (responseReceiveStartedNanos > 0L) {
+            harEntry.getTimings().setReceive(timeoutTimestampNanos - responseReceiveStartedNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void proxyToServerConnectionQueued() {
+        if (har == null) {
+            return;
+        }
+
+        this.connectionQueuedNanos = System.nanoTime();
+    }
+
+
+    @Override
+    public InetSocketAddress proxyToServerResolutionStarted(String resolvingServerHostAndPort) {
+        if (har == null) {
+            return null;
+        }
+
+        dnsResolutionStartedNanos = System.nanoTime();
+
+        return null;
+    }
+
+    @Override
+    public void proxyToServerResolutionSucceeded(String serverHostAndPort, InetSocketAddress resolvedRemoteAddress) {
+        if (har == null) {
+            return;
+        }
+
+        this.dnsResolutionFinishedNanos = System.nanoTime();
+    }
+
+    @Override
+    public void proxyToServerConnectionStarted() {
+        if (har == null) {
+            return;
+        }
+
+        this.connectionStartedNanos = System.nanoTime();
+    }
+
+    @Override
+    public void proxyToServerRequestSending() {
+        if (har == null) {
+            return;
+        }
+
+        this.sendStartedNanos = System.nanoTime();
+    }
+
+    @Override
+    public void proxyToServerRequestSent() {
+        if (har == null) {
+            return;
+        }
+
+        this.sendFinishedNanos = System.nanoTime();
+    }
+
+    @Override
+    public void serverToProxyResponseReceiving() {
+        if (har == null) {
+            return;
+        }
+
+        this.responseReceiveStartedNanos = System.nanoTime();
+    }
+
+    /**
+     * Populates timing information in the specified harEntry for failed rquests. Populates as much timing information
+     * as possible, up to the point of failure.
+     *
+     * @param harEntry HAR entry to populate timing information in
+     */
+    private void populateTimingsForFailedCONNECT(HarEntry harEntry) {
+        HarTimings timings = harEntry.getTimings();
+
+        if (connectionQueuedNanos > 0L && dnsResolutionStartedNanos > 0L) {
+            timings.setBlocked(dnsResolutionStartedNanos - connectionQueuedNanos, TimeUnit.NANOSECONDS);
+        }
+
+        if (dnsResolutionStartedNanos > 0L && dnsResolutionFinishedNanos > 0L) {
+            timings.setDns(dnsResolutionFinishedNanos - dnsResolutionStartedNanos, TimeUnit.NANOSECONDS);
+        }
+
+        if (connectionStartedNanos > 0L && connectionSucceededTimeNanos > 0L) {
+            harEntry.getTimings().setConnect(connectionSucceededTimeNanos - connectionStartedNanos, TimeUnit.NANOSECONDS);
+
+            if (sslHandshakeStartedNanos > 0L) {
+                harEntry.getTimings().setSsl(connectionSucceededTimeNanos - this.sslHandshakeStartedNanos, TimeUnit.NANOSECONDS);
+            }
+        }
+
+        if (sendStartedNanos > 0L && sendFinishedNanos >= 0L) {
+            harEntry.getTimings().setSend(sendFinishedNanos - sendStartedNanos, TimeUnit.NANOSECONDS);
+        }
+
+        if (sendFinishedNanos > 0L && responseReceiveStartedNanos >= 0L) {
+            harEntry.getTimings().setWait(responseReceiveStartedNanos - sendFinishedNanos, TimeUnit.NANOSECONDS);
+        }
+
+        // since this method is for HTTP CONNECT failures only, we can't populate a "received" time, since that would
+        // require the CONNECT to be successful, in which case this method wouldn't be called.
+    }
+
+    /**
+     * Creates a {@link HarEntry} for a failed CONNECT request. Initializes and populates the entry, including the
+     * {@link HarRequest}, {@link HarResponse}, and {@link HarTimings}. (Note: only successful timing information is
+     * populated in the timings object; the calling method must populate the timing information for the final, failed
+     * step. For example, if DNS resolution failed, this method will populate the network 'blocked' time, but not the DNS
+     * time.) Populates the specified errorMessage in the {@link HarResponse}'s error field.
+     *
+     * @param errorMessage error message to place in the har response
+     * @return a new HAR entry
+     */
+    private HarEntry createHarEntryForFailedCONNECT(String errorMessage) {
+        HarEntry harEntry = new HarEntry(currentPageRef);
+        harEntry.setStartedDateTime(requestStartTime);
+
+        HarRequest request = createRequestForFailedConnect(originalRequest);
+        harEntry.setRequest(request);
+
+        HarResponse response = HarCaptureUtil.createHarResponseForFailure();
+        harEntry.setResponse(response);
+
+        response.setError(errorMessage);
+
+        // populate all timing information for this failed request
+        populateTimingsForFailedCONNECT(harEntry);
+
+        return harEntry;
+    }
+
+    /**
+     * Creates a new {@link HarRequest} object for this failed HTTP CONNECT. Does not populate fields within the request,
+     * such as the error message.
+     *
+     * @param httpConnectRequest the HTTP CONNECT request that failed
+     * @return a new HAR request object
+     */
+    private HarRequest createRequestForFailedConnect(HttpRequest httpConnectRequest) {
+        String url = getFullUrl(httpConnectRequest);
+
+        return new HarRequest(httpConnectRequest.getMethod().toString(), url, httpConnectRequest.getProtocolVersion().text());
+    }
+
+}

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/ResolvedHostnameCacheFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/ResolvedHostnameCacheFilter.java
@@ -1,0 +1,74 @@
+package net.lightbody.bmp.filters;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.net.HostAndPort;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.HttpFiltersAdapter;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Caches hostname resolutions reported by the {@link org.littleshoot.proxy.HttpFilters#proxyToServerResolutionSucceeded(String, InetSocketAddress)}
+ * filter method. Allows access to the resolved IP address on subsequent requests, when the address is not re-resolved because
+ * the connection has already been established.
+ */
+public class ResolvedHostnameCacheFilter extends HttpFiltersAdapter {
+    /**
+     * The maximum amount of time to save host name resolution information. This is done in order to populate the server IP address field in the
+     * har. Unfortunately there is not currently any way to determine the remote IP address of a keep-alive connection in a filter, so caching the
+     * resolved hostnames gives a generally-reasonable best guess.
+     */
+    private static final int RESOLVED_ADDRESSES_EVICTION_SECONDS = 300;
+
+    /**
+     * Concurrency of the resolvedAddresses map. Should be approximately equal to the maximum number of simultaneous connection
+     * attempts (but not necessarily simultaneous connections). A lower value will inhibit performance.
+     */
+    private static final int RESOLVED_ADDRESSES_CONCURRENCY_LEVEL = 50;
+
+    /**
+     * A {@code Map<hostname, IP address>} that provides a reasonable estimate of the upstream server's IP address for keep-alive connections.
+     * The expiration time is renewed after each access, rather than after each write, so if the connection is consistently kept alive and used,
+     * the cached IP address will not be evicted.
+     */
+    private static final ConcurrentMap<String, String> resolvedAddresses =
+            CacheBuilder.newBuilder()
+                    .expireAfterAccess(RESOLVED_ADDRESSES_EVICTION_SECONDS, TimeUnit.SECONDS)
+                    .concurrencyLevel(RESOLVED_ADDRESSES_CONCURRENCY_LEVEL)
+                    .<String, String>build()
+                    .asMap();
+
+    public ResolvedHostnameCacheFilter(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+        super(originalRequest, ctx);
+    }
+
+    @Override
+    public void proxyToServerResolutionSucceeded(String serverHostAndPort, InetSocketAddress resolvedRemoteAddress) {
+        // the address *should* always be resolved at this point
+        InetAddress resolvedAddress = resolvedRemoteAddress.getAddress();
+
+        if (resolvedAddress != null) {
+            // place the resolved host into the hostname cache, so subsequent requests will be able to identify the IP address
+            HostAndPort parsedHostAndPort = HostAndPort.fromString(serverHostAndPort);
+            String host = parsedHostAndPort.getHostText();
+
+            if (host != null && !host.isEmpty()) {
+                resolvedAddresses.put(host, resolvedAddress.getHostAddress());
+            }
+        }
+    }
+
+    /**
+     * Returns the (cached) address that was previously resolved for the specified host.
+     *
+     * @param host hostname that was previously resolved (without a port)
+     * @return the resolved IP address for the host, or null if the resolved address is not in the cache
+     */
+    public static String getPreviouslyResolvedAddressForHost(String host) {
+        return resolvedAddresses.get(host);
+    }
+}

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/support/HttpConnectTiming.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/support/HttpConnectTiming.java
@@ -1,0 +1,51 @@
+package net.lightbody.bmp.filters.support;
+
+/**
+ * Holds the connection-related timing information from an HTTP CONNECT request, so it can be added to the HAR timings for the first
+ * "real" request to the same host. The HTTP CONNECT and the "real" HTTP requests are processed in different HarCaptureFilter instances.
+ * <p/>
+ * <b>Note:</b> The connect time must include the ssl time. According to the HAR spec at <a href="https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/HAR/Overview.htm">https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/HAR/Overview.htm</a>:
+ <pre>
+ ssl [number, optional] (new in 1.2) - Time required for SSL/TLS negotiation. If this field is defined then the time is also
+ included in the connect field (to ensure backward compatibility with HAR 1.1). Use -1 if the timing does not apply to the
+ current request.
+ </pre>
+ */
+public class HttpConnectTiming {
+    private volatile long blockedTimeNanos = -1;
+    private volatile long dnsTimeNanos = -1;
+    private volatile long connectTimeNanos = -1;
+    private volatile long sslHandshakeTimeNanos = -1;
+
+    public void setConnectTimeNanos(long connectTimeNanos) {
+        this.connectTimeNanos = connectTimeNanos;
+    }
+
+    public void setSslHandshakeTimeNanos(long sslHandshakeTimeNanos) {
+        this.sslHandshakeTimeNanos = sslHandshakeTimeNanos;
+    }
+
+    public void setBlockedTimeNanos(long blockedTimeNanos) {
+        this.blockedTimeNanos = blockedTimeNanos;
+    }
+
+    public void setDnsTimeNanos(long dnsTimeNanos) {
+        this.dnsTimeNanos = dnsTimeNanos;
+    }
+
+    public long getConnectTimeNanos() {
+        return connectTimeNanos;
+    }
+
+    public long getSslHandshakeTimeNanos() {
+        return sslHandshakeTimeNanos;
+    }
+
+    public long getBlockedTimeNanos() {
+        return blockedTimeNanos;
+    }
+
+    public long getDnsTimeNanos() {
+        return dnsTimeNanos;
+    }
+}

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/util/HarCaptureUtil.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/util/HarCaptureUtil.java
@@ -1,0 +1,80 @@
+package net.lightbody.bmp.filters.util;
+
+import net.lightbody.bmp.core.har.HarResponse;
+
+/**
+ * Static utility methods for {@link net.lightbody.bmp.filters.HarCaptureFilter} and {@link net.lightbody.bmp.filters.HttpsConnectHarCaptureFilter}.
+ */
+public class HarCaptureUtil {
+    /**
+     * The HTTP version string in the {@link HarResponse} for failed requests.
+     */
+    public static final String HTTP_VERSION_STRING_FOR_FAILURE = "unknown";
+
+    /**
+     * The HTTP status code in the {@link HarResponse} for failed requests.
+     */
+    public static final int HTTP_STATUS_CODE_FOR_FAILURE = 0;
+
+    /**
+     * The HTTP status text/reason phrase in the {@link HarResponse} for failed requests.
+     */
+    public static final String HTTP_REASON_PHRASE_FOR_FAILURE = "";
+
+    /**
+     * The error message that will be populated in the _error field of the {@link HarResponse} due to a name
+     * lookup failure.
+     */
+    private static final String RESOLUTION_FAILED_ERROR_MESSAGE = "Unable to resolve host: ";
+
+    /**
+     * The error message that will be populated in the _error field of the {@link HarResponse} due to a
+     * connection failure.
+     */
+    private static final String CONNECTION_FAILED_ERROR_MESSAGE = "Unable to connect to host";
+
+    /**
+     * The error message that will be populated in the _error field of the {@link HarResponse} when the proxy fails to
+     * receive a response in a timely manner.
+     */
+    private static final String RESPONSE_TIMED_OUT_ERROR_MESSAGE = "Response timed out";
+
+    /**
+     * Creates a HarResponse object for failed requests. Normally the HarResponse is populated when the response is received
+     * from the server, but if the request fails due to a name resolution issue, connection problem, timeout, etc., no
+     * HarResponse would otherwise be created.
+     *
+     * @return a new HarResponse object with invalid HTTP status code (0) and version string ("unknown")
+     */
+    public static HarResponse createHarResponseForFailure() {
+        return new HarResponse(HTTP_STATUS_CODE_FOR_FAILURE, HTTP_REASON_PHRASE_FOR_FAILURE, HTTP_VERSION_STRING_FOR_FAILURE);
+    }
+
+    /**
+     * Returns the error message for the HAR response when DNS resolution fails.
+     *
+     * @param hostAndPort the host and port of the address lookup that failed
+     * @return the resolution failed error message
+     */
+    public static String getResolutionFailedErrorMessage(String hostAndPort) {
+        return RESOLUTION_FAILED_ERROR_MESSAGE + hostAndPort;
+    }
+
+    /**
+     * Returns the error message for the HAR response when the connection fails.
+     *
+     * @return the connection failed error message
+     */
+    public static String getConnectionFailedErrorMessage() {
+        return CONNECTION_FAILED_ERROR_MESSAGE;
+    }
+
+    /**
+     * Returs the error message for the HAR response when the response from the server times out.
+     *
+     * @return the response timed out error message
+     */
+    public static String getResponseTimedOutErrorMessage() {
+        return RESPONSE_TIMED_OUT_ERROR_MESSAGE;
+    }
+}

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/util/HarCaptureUtil.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/util/HarCaptureUtil.java
@@ -3,7 +3,7 @@ package net.lightbody.bmp.filters.util;
 import net.lightbody.bmp.core.har.HarResponse;
 
 /**
- * Static utility methods for {@link net.lightbody.bmp.filters.HarCaptureFilter} and {@link net.lightbody.bmp.filters.HttpsConnectHarCaptureFilter}.
+ * Static utility methods for {@link net.lightbody.bmp.filters.HarCaptureFilter} and {@link net.lightbody.bmp.filters.HttpConnectHarCaptureFilter}.
  */
 public class HarCaptureUtil {
     /**

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
@@ -10,7 +10,7 @@ import net.lightbody.bmp.core.har.HarEntry
 import net.lightbody.bmp.core.har.HarNameValuePair
 import net.lightbody.bmp.core.har.HarResponse
 import net.lightbody.bmp.core.har.HarTimings
-import net.lightbody.bmp.filters.HarCaptureFilter
+import net.lightbody.bmp.filters.util.HarCaptureUtil
 import net.lightbody.bmp.proxy.dns.AdvancedHostResolver
 import net.lightbody.bmp.proxy.test.util.MockServerTest
 import net.lightbody.bmp.proxy.test.util.ProxyServerTest
@@ -18,7 +18,6 @@ import net.lightbody.bmp.proxy.util.IOUtils
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -580,9 +579,9 @@ class NewHarTest extends MockServerTest {
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
-        assertEquals("Error in HAR response did not match expected DNS failure error message", HarCaptureFilter.RESOLUTION_FAILED_ERROR_MESSAGE + "www.doesnotexist.address", harResponse.error)
-        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureFilter.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
-        assertEquals("Expected unknown HTTP version for failed request", HarCaptureFilter.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
+        assertEquals("Error in HAR response did not match expected DNS failure error message", HarCaptureUtil.getResolutionFailedErrorMessage("www.doesnotexist.address"), harResponse.error)
+        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureUtil.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
+        assertEquals("Expected unknown HTTP version for failed request", HarCaptureUtil.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
         assertEquals("Expected default value for headersSize for failed request", -1L, harResponse.headersSize)
         assertEquals("Expected default value for bodySize for failed request", -1L, harResponse.bodySize)
 
@@ -598,8 +597,6 @@ class NewHarTest extends MockServerTest {
         assertEquals("Expected HAR timings to contain default values after DNS failure", 0L, harTimings.getReceive(TimeUnit.NANOSECONDS))
     }
 
-    // TODO: unignore when a strategy for handling failed HTTP CONNECT requests is implemented
-    @Ignore
     @Test
     void testHttpsDnsFailureCapturedInHar() {
         AdvancedHostResolver mockFailingResolver = mock(AdvancedHostResolver)
@@ -625,14 +622,14 @@ class NewHarTest extends MockServerTest {
 
         // make sure request data is still captured despite the failure
         String capturedUrl = har.log.entries[0].request.url
-        assertEquals("URL captured in HAR did not match request URL", requestUrl, capturedUrl)
+        assertEquals("URL captured in HAR did not match expected HTTP CONNECT URL", "https://www.doesnotexist.address:443", capturedUrl)
 
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
-        assertEquals("Error in HAR response did not match expected DNS failure error message", HarCaptureFilter.RESOLUTION_FAILED_ERROR_MESSAGE + "www.doesnotexist.address", harResponse.error)
-        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureFilter.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
-        assertEquals("Expected unknown HTTP version for failed request", HarCaptureFilter.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
+        assertEquals("Error in HAR response did not match expected DNS failure error message", HarCaptureUtil.getResolutionFailedErrorMessage("www.doesnotexist.address:443"), harResponse.error)
+        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureUtil.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
+        assertEquals("Expected unknown HTTP version for failed request", HarCaptureUtil.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
         assertEquals("Expected default value for headersSize for failed request", -1L, harResponse.headersSize)
         assertEquals("Expected default value for bodySize for failed request", -1L, harResponse.bodySize)
 
@@ -655,7 +652,9 @@ class NewHarTest extends MockServerTest {
 
         proxy.newHar()
 
-        String requestUrl = "http://localhost:0/some-resource"
+        // TCP port 2 is reserved for "CompressNET Management Utility". since it's almost certainly not in use, connections
+        // to port 2 will fail.
+        String requestUrl = "http://localhost:2/some-resource"
 
         ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
             CloseableHttpResponse response = it.execute(new HttpGet(requestUrl))
@@ -674,9 +673,9 @@ class NewHarTest extends MockServerTest {
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
-        assertEquals("Error in HAR response did not match expected connection failure error message", HarCaptureFilter.CONNECTION_FAILED_ERROR_MESSAGE, harResponse.error)
-        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureFilter.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
-        assertEquals("Expected unknown HTTP version for failed request", HarCaptureFilter.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
+        assertEquals("Error in HAR response did not match expected connection failure error message", HarCaptureUtil.getConnectionFailedErrorMessage(), harResponse.error)
+        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureUtil.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
+        assertEquals("Expected unknown HTTP version for failed request", HarCaptureUtil.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
         assertEquals("Expected default value for headersSize for failed request", -1L, harResponse.headersSize)
         assertEquals("Expected default value for bodySize for failed request", -1L, harResponse.bodySize)
 
@@ -691,8 +690,6 @@ class NewHarTest extends MockServerTest {
         assertEquals("Expected HAR timings to contain default values after connection failure", 0L, harTimings.getReceive(TimeUnit.NANOSECONDS))
     }
 
-    // TODO: unignore when a strategy for handling failed HTTP CONNECT requests is implemented
-    @Ignore
     @Test
     void testHttpsConnectTimeoutCapturedInHar() {
         proxy = new BrowserMobProxyServer();
@@ -700,7 +697,9 @@ class NewHarTest extends MockServerTest {
 
         proxy.newHar()
 
-        String requestUrl = "https://localhost:0/some-resource"
+        // TCP port 2 is reserved for "CompressNET Management Utility". since it's almost certainly not in use, connections
+        // to port 2 will fail.
+        String requestUrl = "https://localhost:2/some-resource"
 
         ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
             CloseableHttpResponse response = it.execute(new HttpGet(requestUrl))
@@ -714,14 +713,14 @@ class NewHarTest extends MockServerTest {
 
         // make sure request data is still captured despite the failure
         String capturedUrl = har.log.entries[0].request.url
-        assertEquals("URL captured in HAR did not match request URL", requestUrl, capturedUrl)
+        assertEquals("URL captured in HAR did not match request URL", "https://localhost:2", capturedUrl)
 
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
-        assertEquals("Error in HAR response did not match expected connection failure error message", HarCaptureFilter.CONNECTION_FAILED_ERROR_MESSAGE, harResponse.error)
-        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureFilter.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
-        assertEquals("Expected unknown HTTP version for failed request", HarCaptureFilter.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
+        assertEquals("Error in HAR response did not match expected connection failure error message", HarCaptureUtil.getConnectionFailedErrorMessage(), harResponse.error)
+        assertEquals("Expected HTTP status code of 0 for failed request", HarCaptureUtil.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
+        assertEquals("Expected unknown HTTP version for failed request", HarCaptureUtil.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
         assertEquals("Expected default value for headersSize for failed request", -1L, harResponse.headersSize)
         assertEquals("Expected default value for bodySize for failed request", -1L, harResponse.bodySize)
 
@@ -772,9 +771,9 @@ class NewHarTest extends MockServerTest {
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
-        assertEquals("Error in HAR response did not match expected response timeout error message", HarCaptureFilter.RESPONSE_TIMED_OUT_ERROR_MESSAGE, harResponse.error)
-        assertEquals("Expected HTTP status code of 0 for response timeout", HarCaptureFilter.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
-        assertEquals("Expected unknown HTTP version for response timeout", HarCaptureFilter.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
+        assertEquals("Error in HAR response did not match expected response timeout error message", HarCaptureUtil.getResponseTimedOutErrorMessage(), harResponse.error)
+        assertEquals("Expected HTTP status code of 0 for response timeout", HarCaptureUtil.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
+        assertEquals("Expected unknown HTTP version for response timeout", HarCaptureUtil.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
         assertEquals("Expected default value for headersSize for response timeout", -1L, harResponse.headersSize)
         assertEquals("Expected default value for bodySize for response timeout", -1L, harResponse.bodySize)
 
@@ -793,8 +792,6 @@ class NewHarTest extends MockServerTest {
         assertEquals("Expected receive time to not be populated", 0L, harTimings.getReceive(TimeUnit.NANOSECONDS))
     }
 
-    // TODO: unignore when a strategy for handling failed HTTP CONNECT requests is implemented
-    @Ignore
     @Test
     void testHttpsResponseTimeoutCapturedInHar() {
         mockServer.when(request()
@@ -831,16 +828,16 @@ class NewHarTest extends MockServerTest {
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
-        assertEquals("Error in HAR response did not match expected response timeout error message", HarCaptureFilter.RESPONSE_TIMED_OUT_ERROR_MESSAGE, harResponse.error)
-        assertEquals("Expected HTTP status code of 0 for response timeout", HarCaptureFilter.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
-        assertEquals("Expected unknown HTTP version for response timeout", HarCaptureFilter.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
+        assertEquals("Error in HAR response did not match expected response timeout error message", HarCaptureUtil.RESPONSE_TIMED_OUT_ERROR_MESSAGE, harResponse.error)
+        assertEquals("Expected HTTP status code of 0 for response timeout", HarCaptureUtil.HTTP_STATUS_CODE_FOR_FAILURE, harResponse.status)
+        assertEquals("Expected unknown HTTP version for response timeout", HarCaptureUtil.HTTP_VERSION_STRING_FOR_FAILURE, harResponse.httpVersion)
         assertEquals("Expected default value for headersSize for response timeout", -1L, harResponse.headersSize)
         assertEquals("Expected default value for bodySize for response timeout", -1L, harResponse.bodySize)
 
         HarTimings harTimings = har.log.entries[0].timings
         assertNotNull("No HAR timings found", harTimings)
 
-        assertEquals("Expected ssl timing to contain default value", -1L, harTimings.getSsl(TimeUnit.NANOSECONDS))
+        assertThat("Expected ssl timing to be populated", harTimings.getSsl(TimeUnit.NANOSECONDS), greaterThan(0L))
 
         // this timeout was caused by a failure of the server to respond, so dns, connect, send, and wait should all be populated,
         // but receive should not be populated since no response was received.

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
@@ -670,6 +670,8 @@ class NewHarTest extends MockServerTest {
         String capturedUrl = har.log.entries[0].request.url
         assertEquals("URL captured in HAR did not match request URL", requestUrl, capturedUrl)
 
+        assertEquals("Expected IP address to be populated", "127.0.0.1", har.log.entries[0].serverIPAddress)
+
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
 
@@ -714,6 +716,8 @@ class NewHarTest extends MockServerTest {
         // make sure request data is still captured despite the failure
         String capturedUrl = har.log.entries[0].request.url
         assertEquals("URL captured in HAR did not match request URL", "https://localhost:2", capturedUrl)
+
+        assertEquals("Expected IP address to be populated", "127.0.0.1", har.log.entries[0].serverIPAddress)
 
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
@@ -767,6 +771,8 @@ class NewHarTest extends MockServerTest {
         // make sure request data is still captured despite the failure
         String capturedUrl = har.log.entries[0].request.url
         assertEquals("URL captured in HAR did not match request URL", requestUrl, capturedUrl)
+
+        assertEquals("Expected IP address to be populated", "127.0.0.1", har.log.entries[0].serverIPAddress)
 
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)
@@ -824,6 +830,8 @@ class NewHarTest extends MockServerTest {
         // make sure request data is still captured despite the failure
         String capturedUrl = har.log.entries[0].request.url
         assertEquals("URL captured in HAR did not match request URL", requestUrl, capturedUrl)
+
+        assertEquals("Expected IP address to be populated", "127.0.0.1", har.log.entries[0].serverIPAddress)
 
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -1,7 +1,5 @@
 package net.lightbody.bmp;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpRequest;
 import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.filters.RequestFilter;
 import net.lightbody.bmp.filters.ResponseFilter;
@@ -522,7 +520,7 @@ public interface BrowserMobProxy {
      * Adds a new filter factory (request/response interceptor) to the beginning of the HttpFilters chain.
      * <p/>
      * <b>Usage note:</b> The actual filter (interceptor) instance is created on every request by implementing the
-     * {@link HttpFiltersSource#filterRequest(HttpRequest, ChannelHandlerContext)} method and returning an
+     * {@link HttpFiltersSource#filterRequest(io.netty.handler.codec.http.HttpRequest, io.netty.channel.ChannelHandlerContext)} method and returning an
      * {@link org.littleshoot.proxy.HttpFilters} instance (typically, a subclass of {@link org.littleshoot.proxy.HttpFiltersAdapter}).
      * To disable or bypass a filter on a per-request basis, the filterRequest() method may return null.
      * <p/>
@@ -538,7 +536,7 @@ public interface BrowserMobProxy {
      * Adds a new filter factory (request/response interceptor) to the end of the HttpFilters chain.
      * <p/>
      * <b>Usage note:</b> The actual filter (interceptor) instance is created on every request by implementing the
-     * {@link HttpFiltersSource#filterRequest(HttpRequest, ChannelHandlerContext)} method and returning an
+     * {@link HttpFiltersSource#filterRequest(io.netty.handler.codec.http.HttpRequest, io.netty.channel.ChannelHandlerContext)} method and returning an
      * {@link org.littleshoot.proxy.HttpFilters} instance (typically, a subclass of {@link org.littleshoot.proxy.HttpFiltersAdapter}).
      * To disable or bypass a filter on a per-request basis, the filterRequest() method may return null.
      * <p/>

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -1,5 +1,7 @@
 package net.lightbody.bmp;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpRequest;
 import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.filters.RequestFilter;
 import net.lightbody.bmp.filters.ResponseFilter;
@@ -519,6 +521,11 @@ public interface BrowserMobProxy {
     /**
      * Adds a new filter factory (request/response interceptor) to the beginning of the HttpFilters chain.
      * <p/>
+     * <b>Usage note:</b> The actual filter (interceptor) instance is created on every request by implementing the
+     * {@link HttpFiltersSource#filterRequest(HttpRequest, ChannelHandlerContext)} method and returning an
+     * {@link org.littleshoot.proxy.HttpFilters} instance (typically, a subclass of {@link org.littleshoot.proxy.HttpFiltersAdapter}).
+     * To disable or bypass a filter on a per-request basis, the filterRequest() method may return null.
+     * <p/>
      * <b>Note:</b> This method is only available in the LittleProxy-based implementation of BrowserMob Proxy. The legacy {@link net.lightbody.bmp.proxy.ProxyServer}
      * implementation will not use the HTTP filters. You <b>must</b> use the addRequestInterceptor() and addResponseInterceptor() methods in
      * {@link net.lightbody.bmp.proxy.LegacyProxyServer} when using the legacy ProxyServer implementation.
@@ -529,6 +536,11 @@ public interface BrowserMobProxy {
 
     /**
      * Adds a new filter factory (request/response interceptor) to the end of the HttpFilters chain.
+     * <p/>
+     * <b>Usage note:</b> The actual filter (interceptor) instance is created on every request by implementing the
+     * {@link HttpFiltersSource#filterRequest(HttpRequest, ChannelHandlerContext)} method and returning an
+     * {@link org.littleshoot.proxy.HttpFilters} instance (typically, a subclass of {@link org.littleshoot.proxy.HttpFiltersAdapter}).
+     * To disable or bypass a filter on a per-request basis, the filterRequest() method may return null.
      * <p/>
      * <b>Note:</b> This method is only available in the LittleProxy-based implementation of BrowserMob Proxy. The legacy {@link net.lightbody.bmp.proxy.ProxyServer}
      * implementation will not use the HTTP filters. You <b>must</b> use the addRequestInterceptor() and addResponseInterceptor() methods in


### PR DESCRIPTION
As promised in #274, this PR adds HAR error capture for HTTP CONNECT failures. If an HTTP CONNECT fails due to dns failure, connection timeout, or response timeout, it will create an entry in the HAR indicating the reason for failure.