### PR TITLE
Update to latest bmp littleproxy build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
             <dependency>
                 <groupId>net.lightbody.bmp</groupId>
                 <artifactId>littleproxy</artifactId>
-                <version>1.1.0-beta-bmp-6</version>
+                <version>1.1.0-beta-bmp-7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR updates to the latest LittleProxy, which should bring in a fix to the regression noted in #212.