### PR TITLE
Fix mimeType and size capture in response.content HAR object

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -515,7 +515,11 @@ public class BrowserMobProxyServer implements BrowserMobProxy, LegacyProxyServer
 
     @Override
     public void setHarCaptureTypes(Set<CaptureType> harCaptureSettings) {
-        harCaptureTypes = EnumSet.copyOf(harCaptureSettings);
+        if (harCaptureSettings == null || harCaptureSettings.isEmpty()) {
+            harCaptureTypes = EnumSet.noneOf(CaptureType.class);
+        } else {
+            harCaptureTypes = EnumSet.copyOf(harCaptureSettings);
+        }
     }
 
     @Override

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -455,8 +455,6 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
             contentType = BrowserMobHttpUtil.UNKNOWN_CONTENT_TYPE;
         }
 
-        harEntry.getResponse().getContent().setMimeType(contentType);
-
         if (responseCaptureFilter.isResponseCompressed() && !responseCaptureFilter.isDecompressionSuccessful()) {
             log.warn("Unable to decompress content with encoding: {}. Contents will be encoded as base64 binary data.", responseCaptureFilter.getContentEncoding());
 
@@ -470,6 +468,8 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
             harEntry.getResponse().getContent().setText(DatatypeConverter.printBase64Binary(fullMessage));
             harEntry.getResponse().getContent().setEncoding("base64");
         }
+
+        harEntry.getResponse().getContent().setSize(fullMessage.length);
     }
 
     protected void captureResponse(HttpResponse httpResponse) {
@@ -477,6 +477,8 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
         harEntry.setResponse(response);
 
         captureResponseHeaderSize(httpResponse);
+
+        captureResponseMimeType(httpResponse);
 
         if (dataToCapture.contains(CaptureType.RESPONSE_COOKIES)) {
             captureResponseCookies(httpResponse);
@@ -489,6 +491,11 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
         if (BrowserMobHttpUtil.isRedirect(httpResponse)) {
             captureRedirectUrl(httpResponse);
         }
+    }
+
+    protected void captureResponseMimeType(HttpResponse httpResponse) {
+        String contentType = HttpHeaders.getHeader(httpResponse, HttpHeaders.Names.CONTENT_TYPE);
+        harEntry.getResponse().getContent().setMimeType(contentType);
     }
 
     protected void captureResponseCookies(HttpResponse httpResponse) {


### PR DESCRIPTION
This PR changes the HAR capture behavior so that it always captures mimeType, even when the response content capture type is disabled. Also, it now captures the literal Content-Type header from the request (previously it would sometimes mangle it). When response content capture is enabled, the response.content.size field will be populated as well.

This should address issue #286.