### PR TITLE
Allow replacing existing remappings

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/AbstractHostNameRemapper.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/AbstractHostNameRemapper.java
@@ -1,6 +1,7 @@
 package net.lightbody.bmp.proxy.dns;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -36,7 +37,14 @@ public abstract class AbstractHostNameRemapper implements AdvancedHostResolver {
     @Override
     public void remapHost(String originalHost, String remappedHost) {
         synchronized (remappedHostNames) {
-            ImmutableMap<String, String> newRemappings = new ImmutableMap.Builder<String, String>().putAll(remappedHostNames.get()).put(originalHost, remappedHost).build();
+            Map<String, String> currentHostRemappings = remappedHostNames.get();
+
+            // use a LinkedHashMap to build the new remapping, to avoid duplicate key issues if the originalHost is already in the map
+            Map<String, String> builderMap = Maps.newLinkedHashMap(currentHostRemappings);
+            builderMap.remove(originalHost);
+            builderMap.put(originalHost, remappedHost);
+
+            ImmutableMap<String, String> newRemappings = ImmutableMap.copyOf(builderMap);
 
             remappedHostNames.set(newRemappings);
         }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/AdvancedHostResolver.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/AdvancedHostResolver.java
@@ -22,7 +22,8 @@ public interface AdvancedHostResolver extends HostResolver {
 
     /**
      * Remaps an individual host. If there are any existing remappings, the new remapping will be applied last, after all existing
-     * remappings are applied.
+     * remappings are applied. If there is already a remapping for the specified originalHost, it will be removed before
+     * the new remapping is added to the end of the host remapping list (and will therefore be the last remapping applied).
      *
      * @param originalHost Original host to remap. Must exactly match the requested hostname (not a domain or regular expression match).
      * @param remappedHost hostname that will replace originalHost

--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/dns/AdvancedHostResolverTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/dns/AdvancedHostResolverTest.java
@@ -152,6 +152,22 @@ public class AdvancedHostResolverTest {
     }
 
     @Test
+    public void testReplaceRemappedHostWithNewRemapping() {
+        // remap the hostname twice. the second remapping should supercede the first.
+        resolver.remapHost("www.google.com", "www.yahoo.com");
+        resolver.remapHost("www.google.com", "www.bing.com");
+
+        Collection<InetAddress> remappedAddresses = resolver.resolve("www.google.com");
+        assertNotNull("Collection of resolved addresses should never be null", remappedAddresses);
+        assertNotEquals("Expected to find at least one address for www.google.com remapped to www.bing.com", 0, remappedAddresses.size());
+
+        InetAddress firstRemappedAddr = remappedAddresses.iterator().next();
+
+        //TODO: verify this is correct -- should remapping return the remapped hostname, or the original hostname but with an IP address corresponding to the remapped hostname?
+        assertEquals("Expected hostname for returned address to reflect the remapped address.", "www.bing.com", firstRemappedAddr.getHostName());
+    }
+
+    @Test
     public void testRetrieveOriginalHostByRemappedHost() {
         resolver.remapHost("www.google.com", "www.bing.com");
 


### PR DESCRIPTION
This PR fixes an exception that occurred when attempting to remap a host that had already been remapped. If a remapping already exists, calling remapHost() now removes the existing remapping and appends the new remapping to the end of the remapped hosts list.