### PR TITLE
Add friendlier varargs options for setHarCaptureTypes()

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -16,7 +16,6 @@ import net.lightbody.bmp.filters.AddHeadersFilter;
 import net.lightbody.bmp.filters.BlacklistFilter;
 import net.lightbody.bmp.filters.BrowserMobHttpFilterChain;
 import net.lightbody.bmp.filters.HarCaptureFilter;
-import net.lightbody.bmp.filters.ResolvedHostnameCacheFilter;
 import net.lightbody.bmp.filters.HttpConnectHarCaptureFilter;
 import net.lightbody.bmp.filters.HttpsHostCaptureFilter;
 import net.lightbody.bmp.filters.HttpsOriginalHostCaptureFilter;
@@ -24,6 +23,7 @@ import net.lightbody.bmp.filters.LatencyFilter;
 import net.lightbody.bmp.filters.RegisterRequestFilter;
 import net.lightbody.bmp.filters.RequestFilter;
 import net.lightbody.bmp.filters.RequestFilterAdapter;
+import net.lightbody.bmp.filters.ResolvedHostnameCacheFilter;
 import net.lightbody.bmp.filters.ResponseFilter;
 import net.lightbody.bmp.filters.ResponseFilterAdapter;
 import net.lightbody.bmp.filters.RewriteUrlFilter;
@@ -523,6 +523,15 @@ public class BrowserMobProxyServer implements BrowserMobProxy, LegacyProxyServer
     }
 
     @Override
+    public void setHarCaptureTypes(CaptureType... captureTypes) {
+        if (captureTypes == null) {
+            setHarCaptureTypes(EnumSet.noneOf(CaptureType.class));
+        } else {
+            setHarCaptureTypes(EnumSet.copyOf(Arrays.asList(captureTypes)));
+        }
+    }
+
+    @Override
     public EnumSet<CaptureType> getHarCaptureTypes() {
         return EnumSet.copyOf(harCaptureTypes);
     }
@@ -533,9 +542,27 @@ public class BrowserMobProxyServer implements BrowserMobProxy, LegacyProxyServer
     }
 
     @Override
+    public void enableHarCaptureTypes(CaptureType... captureTypes) {
+        if (captureTypes == null) {
+            enableHarCaptureTypes(EnumSet.noneOf(CaptureType.class));
+        } else {
+            enableHarCaptureTypes(EnumSet.copyOf(Arrays.asList(captureTypes)));
+        }
+    }
+
+    @Override
     public void disableHarCaptureTypes(Set<CaptureType> captureTypes) {
         harCaptureTypes.removeAll(captureTypes);
 
+    }
+
+    @Override
+    public void disableHarCaptureTypes(CaptureType... captureTypes) {
+        if (captureTypes == null) {
+            disableHarCaptureTypes(EnumSet.noneOf(CaptureType.class));
+        } else {
+            disableHarCaptureTypes(EnumSet.copyOf(Arrays.asList(captureTypes)));
+        }
     }
 
     @Override

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
@@ -185,7 +185,7 @@ class NewHarTest extends MockServerTest {
                 .withHeader(new Header("Content-Type", responseContentType)))
 
         proxy = new BrowserMobProxyServer();
-        proxy.setHarCaptureTypes([CaptureType.RESPONSE_CONTENT] as Set)
+        proxy.setHarCaptureTypes(CaptureType.RESPONSE_CONTENT)
         proxy.start()
 
         proxy.newHar()

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -143,6 +143,19 @@ public interface BrowserMobProxy {
     void setHarCaptureTypes(Set<CaptureType> captureTypes);
 
     /**
+     * Sets the data types that will be captured in the HAR file for future requests. Replaces any existing capture types with the specified
+     * capture types. A null or empty set will not disable HAR capture, but will disable collection of
+     * additional {@link net.lightbody.bmp.proxy.CaptureType} data types. {@link net.lightbody.bmp.proxy.CaptureType} provides several
+     * convenience methods to retrieve commonly-used capture settings.
+     * <p/>
+     * <b>Note:</b> HAR capture must still be explicitly enabled via {@link #newHar()} or {@link #newHar(String)} to begin capturing
+     * any request and response contents.
+     *
+     * @param captureTypes HAR data types to capture
+     */
+    void setHarCaptureTypes(CaptureType... captureTypes);
+
+    /**
      * @return A copy of HAR capture types currently in effect. The EnumSet cannot be used to modify the HAR capture types currently in effect.
      */
     EnumSet<CaptureType> getHarCaptureTypes();
@@ -155,11 +168,25 @@ public interface BrowserMobProxy {
     void enableHarCaptureTypes(Set<CaptureType> captureTypes);
 
     /**
+     * Enables the specified HAR capture types. Does not replace or disable any other capture types that may already be enabled.
+     *
+     * @param captureTypes capture types to enable
+     */
+    void enableHarCaptureTypes(CaptureType... captureTypes);
+
+    /**
      * Disables the specified HAR capture types. Does not replace or disable any other capture types that may already be enabled.
      *
      * @param captureTypes capture types to disable
      */
     void disableHarCaptureTypes(Set<CaptureType> captureTypes);
+
+    /**
+     * Disables the specified HAR capture types. Does not replace or disable any other capture types that may already be enabled.
+     *
+     * @param captureTypes capture types to disable
+     */
+    void disableHarCaptureTypes(CaptureType... captureTypes);
 
     /**
      * Starts a new HAR page using the default page naming convention. The default page naming convention is "Page #", where "#" resets to 1

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -39,6 +39,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -348,6 +349,15 @@ public class ProxyServer implements LegacyProxyServer, BrowserMobProxy {
     }
 
     @Override
+    public void setHarCaptureTypes(CaptureType... captureTypes) {
+        if (captureTypes == null) {
+            setHarCaptureTypes(EnumSet.noneOf(CaptureType.class));
+        } else {
+            setHarCaptureTypes(EnumSet.copyOf(Arrays.asList(captureTypes)));
+        }
+    }
+
+    @Override
     public EnumSet<CaptureType> getHarCaptureTypes() {
         // cookie capture types are always enabled in the legacy ProxyServer
         EnumSet<CaptureType> captureTypes = CaptureType.getCookieCaptureTypes();
@@ -383,6 +393,15 @@ public class ProxyServer implements LegacyProxyServer, BrowserMobProxy {
     }
 
     @Override
+    public void enableHarCaptureTypes(CaptureType... captureTypes) {
+        if (captureTypes == null) {
+            enableHarCaptureTypes(EnumSet.noneOf(CaptureType.class));
+        } else {
+            enableHarCaptureTypes(EnumSet.copyOf(Arrays.asList(captureTypes)));
+        }
+    }
+
+    @Override
     public void disableHarCaptureTypes(Set<CaptureType> captureTypes) {
         if (captureTypes.contains(CaptureType.REQUEST_BINARY_CONTENT) || captureTypes.contains(CaptureType.RESPONSE_BINARY_CONTENT)) {
             setCaptureBinaryContent(false);
@@ -394,6 +413,15 @@ public class ProxyServer implements LegacyProxyServer, BrowserMobProxy {
 
         if (captureTypes.contains(CaptureType.REQUEST_HEADERS) || captureTypes.contains(CaptureType.RESPONSE_HEADERS)) {
             setCaptureHeaders(false);
+        }
+    }
+
+    @Override
+    public void disableHarCaptureTypes(CaptureType... captureTypes) {
+        if (captureTypes == null) {
+            disableHarCaptureTypes(EnumSet.noneOf(CaptureType.class));
+        } else {
+            disableHarCaptureTypes(EnumSet.copyOf(Arrays.asList(captureTypes)));
         }
     }
 


### PR DESCRIPTION
This adds some convenience methods to make setting HAR capture types a bit more intuitive. For example:
```java
proxy.enableHarCaptureTypes(CaptureType.REQUEST_HEADERS, CaptureType.REQUEST_CONTENT);
```