### PR TITLE
Remove Apache httpmime dependency from LP module

### DIFF
--- a/browsermob-core-littleproxy/pom.xml
+++ b/browsermob-core-littleproxy/pom.xml
@@ -68,6 +68,10 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpmime</artifactId>
+                </exclusion>
                 <!-- Due to usage in LegacyProxyServer and BrowserMobProxyServer, this dependency needs to be given "provided" scope.
                      It is not used by the BMP LittleProxy implementation itself. -->
                 <exclusion>

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -465,7 +465,7 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
 
         String contentType = HttpHeaders.getHeader(httpResponse, HttpHeaders.Names.CONTENT_TYPE);
         if (contentType == null) {
-            log.warn("No content type specified in response. Content will be treated as {}", BrowserMobHttpUtil.UNKNOWN_CONTENT_TYPE);
+            log.warn("No content type specified in response from {}. Content will be treated as {}", originalRequest.getUri(), BrowserMobHttpUtil.UNKNOWN_CONTENT_TYPE);
             contentType = BrowserMobHttpUtil.UNKNOWN_CONTENT_TYPE;
         }
 

--- a/browsermob-core/src/main/java/net/lightbody/bmp/exception/UnsupportedCharsetException.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/exception/UnsupportedCharsetException.java
@@ -1,0 +1,23 @@
+package net.lightbody.bmp.exception;
+
+/**
+ * A checked exception wrapper for {@link java.nio.charset.UnsupportedCharsetException}. This exception is checked to prevent
+ * situations where an unsupported character set in e.g. a Content-Type header causes the proxy to fail completely, rather
+ * than fallback to some suitable default behavior, such as not parsing the text contents of a message.
+ */
+public class UnsupportedCharsetException extends Exception {
+    public UnsupportedCharsetException(java.nio.charset.UnsupportedCharsetException e) {
+        super(e);
+
+        if (e == null) {
+            throw new IllegalArgumentException("net.lightbody.bmp.exception.UnsupportedCharsetException must be initialized with a non-null instance of java.nio.charset.UnsupportedCharsetException");
+        }
+    }
+
+    /**
+     * @return the underlying {@link java.nio.charset.UnsupportedCharsetException} that this exception wraps.
+     */
+    public java.nio.charset.UnsupportedCharsetException getUnsupportedCharsetExceptionCause() {
+        return (java.nio.charset.UnsupportedCharsetException) this.getCause();
+    }
+}

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/CaptureType.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/CaptureType.java
@@ -19,8 +19,7 @@ public enum CaptureType {
 
     /**
      * Non-binary HTTP request content, such as post data or other text-based request payload.
-     * FIXME: link to binary content-types
-     * See ${@link TBD} for a list of Content-Types that
+     * See {@link net.lightbody.bmp.util.BrowserMobHttpUtil#hasTextualContent(String)} for a list of Content-Types that
      * are considered non-binary.
      *
      */
@@ -43,8 +42,7 @@ public enum CaptureType {
 
     /**
      * Non-binary HTTP response content (typically, HTTP body content).
-     * FIXME: link to binary content-types
-     * See ${@link TBD} for a list of Content-Types that
+     * See {@link net.lightbody.bmp.util.BrowserMobHttpUtil#hasTextualContent(String)} for a list of Content-Types that
      * are considered non-binary.
      */
     RESPONSE_CONTENT,

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpMessageContents.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpMessageContents.java
@@ -2,6 +2,9 @@ package net.lightbody.bmp.util;
 
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaders;
+import net.lightbody.bmp.exception.UnsupportedCharsetException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 
@@ -12,6 +15,8 @@ import java.nio.charset.Charset;
  * TODO: Currently this class only wraps FullHttpMessages, since it must modify the Content-Length header; determine if this may be applied to chunked messages as well
  */
 public class HttpMessageContents {
+    private static final Logger log = LoggerFactory.getLogger(HttpMessageContents.class);
+
     private final FullHttpMessage httpMessage;
 
     // caches for contents, to avoid repeated re-extraction of data
@@ -58,8 +63,9 @@ public class HttpMessageContents {
      * outside of this class will result in stale data returned from this method.
      *
      * @return String representation of the entity body
+     * @throws java.nio.charset.UnsupportedCharsetException if the character set declared in the message is not supported on this platform
      */
-    public String getTextContents() {
+    public String getTextContents() throws java.nio.charset.UnsupportedCharsetException {
         // avoid re-extracting the contents if this method is called repeatedly
         if (textContents == null) {
             textContents = HttpObjectUtil.extractHttpEntityBody(httpMessage);
@@ -100,13 +106,31 @@ public class HttpMessageContents {
 
     /**
      * Retrieves the character set of the entity body. If the Content-Type is not a textual type, this value is meaningless.
+     * If no character set is specified, this method will return the default ISO-8859-1 character set. If the Content-Type
+     * specifies a character set, but the character set is not supported on this platform, this method throws an
+     * {@link java.nio.charset.UnsupportedCharsetException}.
      *
      * @return the entity body's character set
+     * @throws java.nio.charset.UnsupportedCharsetException if the character set declared in the message is not supported on this platform
      */
-    public Charset getCharset() {
-        String contentTypeHeader = HttpHeaders.getHeader(httpMessage, HttpHeaders.Names.CONTENT_TYPE);
+    public Charset getCharset() throws java.nio.charset.UnsupportedCharsetException {
+        String contentTypeHeader = getContentType();
 
-        return BrowserMobHttpUtil.deriveCharsetFromContentTypeHeader(contentTypeHeader);
+        Charset charset = null;
+        try {
+            charset = BrowserMobHttpUtil.readCharsetInContentTypeHeader(contentTypeHeader);
+        } catch (UnsupportedCharsetException e) {
+            java.nio.charset.UnsupportedCharsetException cause = e.getUnsupportedCharsetExceptionCause();
+            log.error("Character set specified in Content-Type header is not supported on this platform. Content-Type header: {}", contentTypeHeader, cause);
+
+            throw cause;
+        }
+
+        if (charset == null) {
+            return BrowserMobHttpUtil.DEFAULT_HTTP_CHARSET;
+        }
+
+        return charset;
     }
 
     /**

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpObjectUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/HttpObjectUtil.java
@@ -42,6 +42,11 @@ public class HttpObjectUtil {
             throw cause;
         }
 
+        if (messageCharset == null) {
+            messageCharset = BrowserMobHttpUtil.DEFAULT_HTTP_CHARSET;
+            log.warn("No character set declared in HTTP message. Replacing text using default charset {}.", messageCharset);
+        }
+
         byte[] contentBytes = newContents.getBytes(messageCharset);
 
         replaceBinaryHttpEntityBody(message, contentBytes);


### PR DESCRIPTION
This PR removes the Apache httpmime dependency when using the LittleProxy implementation. It also cleans up the Content-Type header parsing, especially when determining charsets. The proxy now handles unsupported charsets in a more reasonable manner.