### PR TITLE
Defaulting to LittleProxy-based implementation in standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ The proxy is programmatically controlled via a REST interface or by being embedd
 
 ### REST API
 
-**New in 2.1:** The REST API now supports LittleProxy. When running browsermob-proxy, specify `--use-littleproxy true` to enable LittleProxy support.
+**New in 2.1:** The REST API now supports LittleProxy. As of 2.1.0-beta-3, LittleProxy is the default implementation. (You may specify `--use-littleproxy false` to disable LittleProxy in favor of the legacy Jetty 5-based implementation.)
 
 To get started, first start the proxy by running `browsermob-proxy` or `browsermob-proxy.bat` in the bin directory:
 
-    $ sh browsermob-proxy -port 9090 --use-littleproxy true
+    $ sh browsermob-proxy -port 9090
     INFO 05/31 03:12:48 o.b.p.Main           - Starting up...
     2011-05-30 20:12:49.517:INFO::jetty-7.3.0.v20110203
     2011-05-30 20:12:49.689:INFO::started o.e.j.s.ServletContextHandler{/,null}

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/guice/ConfigModule.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/guice/ConfigModule.java
@@ -50,7 +50,7 @@ public class ConfigModule implements Module {
                 parser.accepts("use-littleproxy", "Use the littleproxy backend instead of the legacy Jetty 5-based implementation")
                 .withOptionalArg()
                 .ofType(Boolean.class)
-                .defaultsTo(false);
+                .defaultsTo(true);
 
         parser.acceptsAll(Arrays.asList("help", "?"), "This help text");
 
@@ -70,9 +70,9 @@ public class ConfigModule implements Module {
         // temporary, until REST API is replaced
         LegacyProxyServerProvider.useLittleProxy = useLittleProxy.value(options);
         if (LegacyProxyServerProvider.useLittleProxy) {
-            System.out.println("Running BrowserMob Proxy using LittleProxy implementation.");
+            System.out.println("Running BrowserMob Proxy using LittleProxy implementation. To revert to the legacy implementation, run the proxy with the command-line option '--use-littleproxy false'.");
         } else {
-            System.out.println("Running BrowserMob Proxy using legacy implementation. To enable the LittleProxy implementation, run the proxy with the command-line option '--use-littleproxy true'.");
+            System.out.println("Running BrowserMob Proxy using legacy implementation.");
         }
 
         List<Integer> ports = options.valuesOf(proxyPortRange); 


### PR DESCRIPTION
Now that the LittleProxy support has matured, this PR changes the default implementation in standalone mode to LittleProxy. Legacy is still available by specifying `--use-littleproxy false`.