### PR TITLE
change deleteDirectoryTask to a List

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/selenium/SeleniumProxyHandler.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/selenium/SeleniumProxyHandler.java
@@ -40,7 +40,14 @@ import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
 
 /* ------------------------------------------------------------ */
 
@@ -72,7 +79,7 @@ public class SeleniumProxyHandler extends AbstractHttpHandler {
       private final boolean proxyInjectionMode;
       private final boolean forceProxyChain;
       private boolean fakeCertsGenerated;
-      private List<DeleteDirectoryTask> deleteDirectoryTasks = new ArrayList<DeleteDirectoryTask>();
+      private final List<DeleteDirectoryTask> deleteDirectoryTasks = Collections.synchronizedList(new ArrayList<DeleteDirectoryTask>());
 
       // see docs for the lock object on SeleniumServer for information on this and why it is IMPORTANT!
       private Object shutdownLock;
@@ -634,9 +641,11 @@ public class SeleniumProxyHandler extends AbstractHttpHandler {
       }
 
       public void cleanSslWithCyberVilliansCA(){
-          if(!deleteDirectoryTasks.isEmpty()) {
-              for(DeleteDirectoryTask task : deleteDirectoryTasks) {
-                  task.run();
+          synchronized (deleteDirectoryTasks) {
+              if (!deleteDirectoryTasks.isEmpty()) {
+                  for (DeleteDirectoryTask task : deleteDirectoryTasks) {
+                      task.run();
+                  }
               }
           }
       }


### PR DESCRIPTION
I am aware if the jvm exists, it will remove all created temp folders. However, I need to keep the jvm running as long as possible in production, which eventually cause the temp folder to fill up with tons of temp folders created by the proxy.

Fix: changed DeleteDirectoryTask deleteDirectoryTask to List deleteDirectoryTasks in SeleniumProxyHandler class, so that when user need to clean up the temp folders but keep the jvm running they can just call proxy.cleanSslCertificates() method.