### PR TITLE
Stripping default port 443 from HTTPS URLs

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
@@ -83,7 +83,9 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
     public String getFullUrl(HttpRequest modifiedRequest) {
         // special case: for HTTPS requests, the full URL is scheme (https://) + the URI of this request
         if (ProxyUtils.isCONNECT(modifiedRequest)) {
-            return "https://" + modifiedRequest.getUri();
+            // CONNECT requests contain the default port, even if it isn't specified on the request.
+            String hostNoDefaultPort = BrowserMobHttpUtil.removeMatchingPort(modifiedRequest.getUri(), 443);
+            return "https://" + hostNoDefaultPort;
         }
 
         // To get the full URL, we need to retrieve the Scheme, Host + Port, Path, and Query Params from the request.

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/NewHarTest.groovy
@@ -667,7 +667,7 @@ class NewHarTest extends MockServerTest {
 
         // make sure request data is still captured despite the failure
         String capturedUrl = har.log.entries[0].request.url
-        assertEquals("URL captured in HAR did not match expected HTTP CONNECT URL", "https://www.doesnotexist.address:443", capturedUrl)
+        assertEquals("URL captured in HAR did not match expected HTTP CONNECT URL", "https://www.doesnotexist.address", capturedUrl)
 
         HarResponse harResponse = har.log.entries[0].response
         assertNotNull("No HAR response found", harResponse)

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/util/BrowserMobHttpUtilTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/util/BrowserMobHttpUtilTest.groovy
@@ -105,4 +105,34 @@ class BrowserMobHttpUtilTest {
         boolean isTextualContent = BrowserMobHttpUtil.hasTextualContent(null)
         assertFalse("Expected hasTextualContent to return false for null content type", isTextualContent)
     }
+
+    @Test
+    void testRemoveMatchingPort() {
+        def portRemoved = BrowserMobHttpUtil.removeMatchingPort("www.example.com:443", 443)
+        assertEquals("www.example.com", portRemoved)
+
+        def hostnameWithNonMatchingPort = BrowserMobHttpUtil.removeMatchingPort("www.example.com:443", 1234)
+        assertEquals("www.example.com:443", hostnameWithNonMatchingPort)
+
+        def hostnameNoPort = BrowserMobHttpUtil.removeMatchingPort("www.example.com", 443)
+        assertEquals("www.example.com", hostnameNoPort)
+
+        def ipv4WithoutPort = BrowserMobHttpUtil.removeMatchingPort("127.0.0.1:443", 443)
+        assertEquals("127.0.0.1", ipv4WithoutPort)
+
+        def ipv4WithNonMatchingPort = BrowserMobHttpUtil.removeMatchingPort("127.0.0.1:443", 1234)
+        assertEquals("127.0.0.1:443", ipv4WithNonMatchingPort);
+
+        def ipv4NoPort = BrowserMobHttpUtil.removeMatchingPort("127.0.0.1", 443)
+        assertEquals("127.0.0.1", ipv4NoPort);
+
+        def ipv6WithoutPort = BrowserMobHttpUtil.removeMatchingPort("[::1]:443", 443)
+        assertEquals("[::1]", ipv6WithoutPort)
+
+        def ipv6WithNonMatchingPort = BrowserMobHttpUtil.removeMatchingPort("[::1]:443", 1234)
+        assertEquals("[::1]:443", ipv6WithNonMatchingPort);
+
+        def ipv6NoPort = BrowserMobHttpUtil.removeMatchingPort("[::1]", 443)
+        assertEquals("[::1]", ipv6NoPort);
+    }
 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
@@ -336,6 +336,29 @@ public class BrowserMobHttpUtil {
     }
 
     /**
+     * Removes a port from a host+port if the string contains the specified port. If the host+port does not contain
+     * a port, or contains another port, the string is returned unaltered. For example, if hostWithPort is the
+     * string {@code www.website.com:443}, this method will return {@code www.website.com}.
+     *
+     * <b>Note:</b> The hostWithPort string is not a URI and should not contain a scheme or resource. This method does
+     * not attempt to validate the specified host; it <i>might</i> throw IllegalArgumentException if there was a problem
+     * parsing the hostname, but makes no guarantees. In general, it should be validated externally, if necessary.
+     *
+     * @param hostWithPort string containing a hostname and optional port
+     * @param portNumber port to remove from the string
+     * @return string with the specified port removed, or the original string if it did not contain the portNumber
+     */
+    public static String removeMatchingPort(String hostWithPort, int portNumber) {
+        HostAndPort parsedHostAndPort = HostAndPort.fromString(hostWithPort);
+        if (parsedHostAndPort.hasPort() && parsedHostAndPort.getPort() == portNumber) {
+            // HostAndPort.getHostText() strips brackets from ipv6 addresses, so reparse using fromHost
+            return HostAndPort.fromHost(parsedHostAndPort.getHostText()).toString();
+        } else {
+            return hostWithPort;
+        }
+    }
+
+    /**
      * Retrieves the host and, optionally, the port from the specified request's Host header.
      *
      * @param httpRequest HTTP request


### PR DESCRIPTION
This PR strips the default port 443 from the HTTPS URLs returned by HttpsAwareFiltersAdapter. Previously the default port (443) would be captured and stored as part of the HTTPS URL returned by the adapter, which meant blacklist entries for HTTPS requests would have to include port 443 explicitly in the regex. This change brings HTTPS matching behavior in line with existing HTTP-matching behavior.