### PR TITLE
Remove test dependency on unlimited strength policy files

### DIFF
--- a/mitm/src/main/java/net/lightbody/bmp/mitm/util/EncryptionUtil.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/util/EncryptionUtil.java
@@ -3,12 +3,14 @@ package net.lightbody.bmp.mitm.util;
 import net.lightbody.bmp.mitm.exception.ExportException;
 import net.lightbody.bmp.mitm.exception.ImportException;
 
+import javax.crypto.Cipher;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.Key;
+import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.DSAKey;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
@@ -106,5 +108,20 @@ public class EncryptionUtil {
         } catch (IOException e) {
             throw new ImportException("Unable to read PEM-encoded data from file: " + file.getName());
         }
+    }
+
+    /**
+     * Determines if unlimited-strength cryptography is allowed, i.e. if this JRE has then the unlimited strength policy
+     * files installed.
+     *
+     * @return true if unlimited strength cryptography is allowed, otherwise false
+     */
+    public static boolean isUnlimitedStrengthAllowed() {
+        try {
+            return Cipher.getMaxAllowedKeyLength("AES") >= 256;
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        }
+
     }
 }

--- a/mitm/src/test/groovy/net/lightbody/bmp/mitm/PemFileCertificateSourceTest.groovy
+++ b/mitm/src/test/groovy/net/lightbody/bmp/mitm/PemFileCertificateSourceTest.groovy
@@ -2,6 +2,7 @@ package net.lightbody.bmp.mitm
 
 import net.lightbody.bmp.mitm.exception.ImportException
 import net.lightbody.bmp.mitm.test.util.CertificateTestUtil
+import net.lightbody.bmp.mitm.util.EncryptionUtil
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -11,6 +12,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assume.assumeTrue
 
 class PemFileCertificateSourceTest {
 
@@ -34,6 +36,8 @@ class PemFileCertificateSourceTest {
 
     @Test
     void testCanLoadCertificateAndPasswordProtectedKey() {
+        assumeTrue("Skipping test because unlimited strength cryptography is not available", EncryptionUtil.isUnlimitedStrengthAllowed())
+
         PemFileCertificateSource pemFileCertificateSource = new PemFileCertificateSource(certificateFile, encryptedPrivateKeyFile, "password")
 
         CertificateAndKey certificateAndKey = pemFileCertificateSource.load()


### PR DESCRIPTION
This PR will allow people to compile on JVMs that do not have the unlimited strength policy files installed.