### PR TITLE
Require HTTP method to blacklist CONNECTs

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BlacklistFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/BlacklistFilter.java
@@ -3,6 +3,7 @@ package net.lightbody.bmp.filters;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -37,6 +38,11 @@ public class BlacklistFilter extends HttpsAwareFiltersAdapter {
             String url = getFullUrl(httpRequest);
 
             for (BlacklistEntry entry : blacklistedUrls) {
+                if (HttpMethod.CONNECT.equals(httpRequest.getMethod()) && entry.getHttpMethodPatern() == null) {
+                    // do not allow CONNECTs to be blacklisted unless a method pattern is explicitly specified
+                    continue;
+                }
+
                 if (entry.matches(url, httpRequest.getMethod().name())) {
                     HttpResponseStatus status = HttpResponseStatus.valueOf(entry.getStatusCode());
                     HttpResponse resp = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(), status);


### PR DESCRIPTION
This PR changes the BlacklistFilter behavior to require the HTTP method when blacklisting CONNECTs. Since the typical use case of blacklists is to blacklist requests, not the SSL negotiation process, this prevents the blacklist from interfering with the latter.