### PR TITLE
Set 'expires' to null for session cookies

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -545,7 +545,12 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
                 harCookie.setHttpOnly(cookie.isHttpOnly());
                 harCookie.setPath(cookie.getPath());
                 harCookie.setSecure(cookie.isSecure());
-                harCookie.setExpires(new Date(System.currentTimeMillis() + cookie.getMaxAge()));
+                Date expires = null;
+                Long maxAge = cookie.getMaxAge();
+                if (maxAge > 0) {
+                    expires = new Date(System.currentTimeMillis() + maxAge);
+                }
+                harCookie.setExpires(expires);
 
                 harEntry.getResponse().getCookies().add(harCookie);
             }


### PR DESCRIPTION
Hi,
I noticed that the generated har contains invalid timestamp values for session cookies. Something like: 
`"expires" : "292269009-11-24T08:44:55.386-05:00",`.
This results in exceptions while parsing the har file.
I realize this fix might be too simplistic... am open to suggestions!

Thanks!