### PR TITLE
Fix for cookie expiration in HAR files

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -545,7 +545,10 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
                 harCookie.setHttpOnly(cookie.isHttpOnly());
                 harCookie.setPath(cookie.getPath());
                 harCookie.setSecure(cookie.isSecure());
-                harCookie.setExpires(new Date(System.currentTimeMillis() + cookie.getMaxAge()));
+                if (cookie.maxAge() > 0) {
+                    // cookie.maxAge() returns the max age of the cookie in seconds; java.util.Date requires milliseconds
+                    harCookie.setExpires(new Date(System.currentTimeMillis() + cookie.maxAge() / 1000L));
+                }
 
                 harEntry.getResponse().getCookies().add(harCookie);
             }


### PR DESCRIPTION
This PR fixes two issues: when cookie max age was not set, an invalid date would appear in the HAR file; and the arithmetic for the expiration date was incorrect.