### PR TITLE
Add auto basic authentication to LittleProxy implementation

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/AutoBasicAuthFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/AutoBasicAuthFilter.java
@@ -1,0 +1,54 @@
+package net.lightbody.bmp.filters;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import org.littleshoot.proxy.impl.ProxyUtils;
+
+import java.util.Map;
+
+/**
+ * A filter that adds Basic authentication information to non-CONNECT requests. Takes a map of domain names to base64-encoded
+ * Basic auth credentials as a constructor parameter. If a key in the map matches the hostname of a filtered request, an Authorization
+ * header will be added to the request.
+ * <p/>
+ * The Authorization header itself is specified in RFC 7235, section 4.2: https://tools.ietf.org/html/rfc7235#section-4.2
+ * The Basic authentication scheme is specified in RFC 2617, section 2: https://tools.ietf.org/html/rfc2617#section-2
+ */
+public class AutoBasicAuthFilter extends HttpsAwareFiltersAdapter {
+    private final Map<String, String> credentialsByHostname;
+
+    public AutoBasicAuthFilter(HttpRequest originalRequest, ChannelHandlerContext ctx, Map<String, String> credentialsByHostname) {
+        super(originalRequest, ctx);
+
+        this.credentialsByHostname = credentialsByHostname;
+    }
+
+    @Override
+    public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+        if (credentialsByHostname.isEmpty()) {
+            return null;
+        }
+
+        if (httpObject instanceof HttpRequest) {
+            HttpRequest httpRequest = (HttpRequest) httpObject;
+
+            // providing authorization during a CONNECT is generally not useful
+            if (ProxyUtils.isCONNECT(httpRequest)) {
+                return null;
+            }
+
+            String hostname = getHost(httpRequest);
+
+            // if there is an entry in the credentials map matching this hostname, add the credentials to the request
+            String base64CredentialsForHostname = credentialsByHostname.get(hostname);
+            if (base64CredentialsForHostname != null) {
+                httpRequest.headers().add(HttpHeaders.Names.AUTHORIZATION, "Basic " + base64CredentialsForHostname);
+            }
+        }
+
+        return null;
+    }
+}

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -620,7 +620,7 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
      * @param httpRequest HTTP request to take the hostname from
      */
     protected void populateAddressFromCache(HttpRequest httpRequest) {
-        String serverHost = getHostAndPort(httpRequest);
+        String serverHost = getHost(httpRequest);
 
         if (serverHost != null && !serverHost.isEmpty()) {
             String resolvedAddress = ResolvedHostnameCacheFilter.getPreviouslyResolvedAddressForHost(serverHost);

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsHostCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsHostCaptureFilter.java
@@ -13,7 +13,7 @@ import org.littleshoot.proxy.impl.ProxyUtils;
 /**
  * Captures the host for HTTPS requests and stores the value in the ChannelHandlerContext for use by {@link HttpsAwareFiltersAdapter}
  * filters. This filter reads the host from the HttpRequest during the HTTP CONNECT call, and therefore MUST be invoked
- * after any other filters which modify the host.
+ * <b>after</b> any other filters which modify the host.
  * Note: If the request uses the default HTTPS port (443), it will be removed from the hostname captured by this filter.
  */
 public class HttpsHostCaptureFilter extends HttpFiltersAdapter {

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsOriginalHostCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsOriginalHostCaptureFilter.java
@@ -9,10 +9,13 @@ import org.littleshoot.proxy.impl.ProxyUtils;
 
 /**
  * Captures the original host for HTTPS requests and stores the value in the ChannelHandlerContext for use by {@link HttpsAwareFiltersAdapter}
- * filters. This filter sets the isHttps attribute on the ChannelHandlerContext during the HTTP CONNECT and therefore MUST be invoked before
+ * filters. This filter sets the isHttps attribute on the ChannelHandlerContext during the HTTP CONNECT and therefore MUST be invoked <b>before</b>
  * any other filters calling any of the methods in {@link HttpsAwareFiltersAdapter}.
+ * This filter extends {@link HttpsHostCaptureFilter} and so also sets the host attribute on the channel for use by filters
+ * that modify the original host during the CONNECT. If the hostname is modified by filters, it will be overwritten when the {@link HttpsHostCaptureFilter}
+ * is processed later in the filter chain.
  */
-public class HttpsOriginalHostCaptureFilter extends HttpFiltersAdapter {
+public class HttpsOriginalHostCaptureFilter extends HttpsHostCaptureFilter {
     public HttpsOriginalHostCaptureFilter(HttpRequest originalRequest, ChannelHandlerContext ctx) {
         super(originalRequest, ctx);
 

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/AutoAuthTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/AutoAuthTest.groovy
@@ -1,0 +1,102 @@
+package net.lightbody.bmp.proxy
+
+import net.lightbody.bmp.BrowserMobProxy
+import net.lightbody.bmp.BrowserMobProxyServer
+import net.lightbody.bmp.proxy.auth.AuthType
+import net.lightbody.bmp.proxy.test.util.MockServerTest
+import net.lightbody.bmp.proxy.test.util.ProxyServerTest
+import net.lightbody.bmp.proxy.util.IOUtils
+import org.apache.http.client.methods.HttpGet
+import org.junit.After
+import org.junit.Test
+import org.mockserver.matchers.Times
+import org.mockserver.model.NottableString
+
+import static org.junit.Assert.assertEquals
+import static org.mockserver.model.HttpRequest.request
+import static org.mockserver.model.HttpResponse.response
+
+class AutoAuthTest extends MockServerTest {
+    BrowserMobProxy proxy
+
+    @After
+    void tearDown() {
+        if (proxy?.started) {
+            proxy.abort()
+        }
+    }
+
+    @Test
+    void testBasicAuthAddedToHttpRequest() {
+        // the base64-encoded rendering of "testUsername:testPassword" is dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA==
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/basicAuthHttp")
+                .withHeader("Authorization", "Basic dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA=="),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"))
+
+        proxy = new BrowserMobProxyServer();
+        proxy.autoAuthorization("localhost", "testUsername", "testPassword", AuthType.BASIC)
+        proxy.setTrustAllServers(true)
+        proxy.start()
+
+        proxy.newHar()
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            String responseBody = IOUtils.toStringAndClose(it.execute(new HttpGet("http://localhost:${mockServerPort}/basicAuthHttp")).getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+    }
+
+    @Test
+    void testBasicAuthAddedToHttpsRequest() {
+        // the base64-encoded rendering of "testUsername:testPassword" is dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA==
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/basicAuthHttp")
+                .withHeader("Authorization", "Basic dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA=="),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"))
+
+        proxy = new BrowserMobProxyServer();
+        proxy.autoAuthorization("localhost", "testUsername", "testPassword", AuthType.BASIC)
+        proxy.setTrustAllServers(true)
+        proxy.start()
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            String responseBody = IOUtils.toStringAndClose(it.execute(new HttpGet("https://localhost:${mockServerPort}/basicAuthHttp")).getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+    }
+
+    @Test
+    void testCanStopBasicAuth() {
+        // the base64-encoded rendering of "testUsername:testPassword" is dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA==
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/basicAuthHttp")
+                // require that the Auth header NOT be present
+                .withHeader(NottableString.not("Authorization"), NottableString.not("Basic dGVzdFVzZXJuYW1lOnRlc3RQYXNzd29yZA==")),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"))
+
+        proxy = new BrowserMobProxyServer();
+        proxy.autoAuthorization("localhost", "testUsername", "testPassword", AuthType.BASIC)
+        proxy.setTrustAllServers(true)
+        proxy.start()
+
+        proxy.stopAutoAuthorization("localhost")
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            String responseBody = IOUtils.toStringAndClose(it.execute(new HttpGet("http://localhost:${mockServerPort}/basicAuthHttp")).getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+    }
+}

--- a/mitm/src/test/java/net/lightbody/bmp/mitm/integration/LittleProxyIntegrationTest.java
+++ b/mitm/src/test/java/net/lightbody/bmp/mitm/integration/LittleProxyIntegrationTest.java
@@ -73,6 +73,7 @@ public class LittleProxyIntegrationTest {
         ImpersonatingMitmManager mitmManager = ImpersonatingMitmManager.builder().build();
 
         HttpProxyServer proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
                 .withManInTheMiddle(mitmManager)
                 .withFiltersSource(filtersSource)
                 .start();

--- a/new-interface-compatibility.md
+++ b/new-interface-compatibility.md
@@ -31,8 +31,8 @@ the new interface. The following table lists the current level of support for th
 `setConnectTimeout` | X | [Must be enabled before start()](#timeouts)
 `setIdleConnectionTimeout` | X | [Must be enabled before start()](#timeouts)
 `setRequestTimeout` | X | Planned
-`autoAuthorization` | X | Planned
-`stopAutoAuthorization` | [Will not support](#auto-authorization) | Planned
+`autoAuthorization` | X | X
+`stopAutoAuthorization` | [Will not support](#auto-authorization) | X
 `rewriteUrl` | X | X
 `rewriteUrls` | X | X
 `removeRewriteRule` | X | X


### PR DESCRIPTION
This PR adds auto basic auth to the LP implementation, one of the last remaining features in BMP that was not implemented using LittleProxy.

As part of the auto auth implementation, this PR also contains some cleanup and fixes to HttpsAwareFiltersAdapter. Notable, the `getHostAndPort()` method has been renamed `getHost()`, since it only returned the host; and a new `getHostAndPort()` method that returns the host and port has been added.