### PR TITLE
Ignore Eclipse generated files in modules too.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ target
 /.classpath
 /.settings
 /.project
+*/.classpath
+*/.settings
+*/.project
 /.idea
 atlassian-ide-plugin.xml
 .DS_Store


### PR DESCRIPTION
Motivation:
 * Developing BMP modules with Eclipse creates some artifacts in the modules too, which should be ignored.

Modifications:
 * Added to `.gitignore` Eclipse names in first level subdirectories.