### PR TITLE
Add useEcc convenience option to BrowserMobProxyServer and REST API

### DIFF
--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -85,11 +85,13 @@ public class ProxyResource {
 
         String paramBindAddr = request.param("bindAddress");
         Integer paramPort = request.param("port") == null ? null : Integer.parseInt(request.param("port"));
+        String useEccString = request.param("useEcc");
+        boolean useEcc = Boolean.parseBoolean(useEccString);
         LOG.debug("POST proxy instance on bindAddress `{}` & port `{}`", 
                 paramBindAddr, paramPort);
         LegacyProxyServer proxy;
         try{
-            proxy = proxyManager.create(options, paramPort, paramBindAddr);            
+            proxy = proxyManager.create(options, paramPort, paramBindAddr, useEcc);
         }catch(ProxyExistsException ex){
             return Reply.with(new ProxyDescriptor(ex.getPort())).status(455).as(Json.class);
         }catch(ProxyPortsExhaustedException ex){


### PR DESCRIPTION
This PR adds the useEcc option to BrowserMobProxyServer and the REST API. The option enables ECC using the supplied ca-certificate-ecc.cer file.

When using the REST API, add the query param useEcc=true to enable ECC by default.