### PR TITLE
Fixed timeout conversion in setIdleConnectionTimeout() to use correct…

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -905,7 +905,7 @@ public class BrowserMobProxyServer implements BrowserMobProxy, LegacyProxyServer
      */
     @Override
     public void setIdleConnectionTimeout(int idleConnectionTimeout, TimeUnit timeUnit) {
-        long timeout = TimeUnit.SECONDS.convert(idleConnectionTimeout, TimeUnit.MILLISECONDS);
+        long timeout = TimeUnit.SECONDS.convert(idleConnectionTimeout, timeUnit);
         if (timeout == 0 && idleConnectionTimeout > 0) {
             this.idleConnectionTimeoutSec = 1;
         } else {


### PR DESCRIPTION
… time units.  When timeout was specified in seconds, the code was assuming milliseconds and truncating to 1 second.  This fixes to convert using the specified time units.