### PR TITLE
Using SHA384 instead of SHA512 when signing impersonated certificates

### DIFF
--- a/mitm/src/main/java/net/lightbody/bmp/mitm/util/MitmConstants.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/util/MitmConstants.java
@@ -7,9 +7,10 @@ public class MitmConstants {
     /**
      * The default message digest to use when signing certificates (CA or server). On 64-bit systems this is set to
      * SHA512, on 32-bit systems this is SHA256. On 64-bit systems, SHA512 generally performs better than SHA256; see
-     * this question for details: http://crypto.stackexchange.com/questions/26336/sha512-faster-than-sha256
+     * this question for details: http://crypto.stackexchange.com/questions/26336/sha512-faster-than-sha256. SHA384 is
+     * SHA512 with a smaller output size.
      */
-    public static final String DEFAULT_MESSAGE_DIGEST = is32BitJvm() ? "SHA256": "SHA512";
+    public static final String DEFAULT_MESSAGE_DIGEST = is32BitJvm() ? "SHA256": "SHA384";
 
     /**
      * The default {@link java.security.KeyStore} type to use when creating KeyStores (e.g. for impersonated server


### PR DESCRIPTION
SHA384 and SHA512 have the same performance characteristics on 64-bit machines.