### PR TITLE
Fix for specific characters in get params

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsOriginalHostCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsOriginalHostCaptureFilter.java
@@ -4,7 +4,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.impl.ProxyUtils;
 
 /**

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RewriteUrlFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RewriteUrlFilter.java
@@ -11,6 +11,7 @@ import org.littleshoot.proxy.impl.ProxyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,7 +71,7 @@ public class RewriteUrlFilter extends HttpsAwareFiltersAdapter {
                     try {
                         String resource = BrowserMobHttpUtil.getRawPathAndParamsFromUri(rewrittenUrl);
                         httpRequest.setUri(resource);
-                    } catch (URISyntaxException e) {
+                    } catch (MalformedURLException e) {
                         // the rewritten URL couldn't be parsed, possibly due to the rewrite rule mangling the URL. log
                         // a warning message and replace the resource on the request with the full, rewritten URL.
                         log.warn("Unable to determine path from rewritten URL. Request URL will be set to the full rewritten URL instead of the resource's path.\n\tOriginal URL: {}\n\tRewritten URL: {}",

--- a/browsermob-core/src/main/java/net/lightbody/bmp/core/json/ISO8601DateFormatter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/core/json/ISO8601DateFormatter.java
@@ -2,13 +2,10 @@ package net.lightbody.bmp.core.json;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.Date;
 

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/Whitelist.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/Whitelist.java
@@ -2,7 +2,6 @@ package net.lightbody.bmp.proxy;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/HttpContext.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/HttpContext.java
@@ -872,8 +872,6 @@ public class HttpContext extends Container
     /** Add elements to the class path for the context from the jar and zip files found
      *  in the specified resource.
      * @param lib the resource that contains the jar and/or zip files.
-     * @param append true if the classpath entries are to be appended to any
-     * existing classpath, or false if they replace the existing classpath.
      * @see #setClassPath(String)
      */
     public void addClassPaths(Resource lib)

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/HttpInputStream.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/HttpInputStream.java
@@ -78,7 +78,7 @@ public class HttpInputStream extends FilterInputStream
     
     /* ------------------------------------------------------------ */
     /**
-     * @param expectContinues The expectContinues to set.
+     * @return  expectContinues The expectContinues to set.
      */
     public OutputStream getExpectContinues()
     {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/HttpTunnel.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/HttpTunnel.java
@@ -59,12 +59,9 @@ public class HttpTunnel
     /* ------------------------------------------------------------ */
     /** Constructor. 
      * @param socket The tunnel socket.
-     * @param timeoutMs The maximum time to wait for a read on the tunnel. Note that
-     * sotimer exceptions are ignored by the tunnel.
      * @param in Alternative input stream or null if using normal socket stream
      * @param out Alternative output stream or null if using normal socket stream
-     * @param timeoutMs
-     * @throws IOException 
+     * @throws IOException
      */
     public HttpTunnel(Socket socket, InputStream in, OutputStream out) throws IOException
     {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/nio/SocketChannelListener.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/http/nio/SocketChannelListener.java
@@ -310,8 +310,8 @@ public class SocketChannelListener extends ThreadPool implements HttpListener
     }
 
     /* ------------------------------------------------------------ */
-    /** 
-     * @param sec seconds to linger or -1 to disable linger.
+    /**
+     * @param ls sec seconds to linger or -1 to disable linger.
      */
     public void setLingerTimeSecs(int ls)
     {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/jetty/Server.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/jetty/Server.java
@@ -419,7 +419,6 @@ public class Server extends HttpServer
      * Set up the list of classnames of WebApplicationContext.Configuration
      * implementations that will be applied to configure every webapp.
      * The list can be overridden by individual WebApplicationContexts.
-     * @param configurationClasses
      */
     public void setWebApplicationConfigurationClassNames (String[] configurationClassNames)
     {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/jetty/Server.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/jetty/Server.java
@@ -419,6 +419,7 @@ public class Server extends HttpServer
      * Set up the list of classnames of WebApplicationContext.Configuration
      * implementations that will be applied to configure every webapp.
      * The list can be overridden by individual WebApplicationContexts.
+     * @param configurationClassNames
      */
     public void setWebApplicationConfigurationClassNames (String[] configurationClassNames)
     {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/log/LogStream.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/log/LogStream.java
@@ -102,8 +102,8 @@ public class LogStream extends PrintStream
     }
  
     /**
-     * @param out
-     * @param autoflush
+     * @param tag
+     * @param log
      */
     public LogStream(String tag, Log log)
     {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/util/ByteBufferOutputStream.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/util/ByteBufferOutputStream.java
@@ -238,9 +238,7 @@ public class ByteBufferOutputStream extends OutputStream
     /** Write bytes into the postreserve.
      * The capacity is not checked.
      * @param b 
-     * @param offset 
-     * @param length 
-     * @exception IOException 
+     * @exception IOException
      */
     public void postwrite(byte b)
         throws IOException

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/util/ThreadedServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/jetty/util/ThreadedServer.java
@@ -411,7 +411,6 @@ abstract public class ThreadedServer extends ThreadPool
      * Accept socket connection. May be overriden by derived class to create specialist
      * serversockets (eg SSL).
      * 
-     * @param serverSocket
      * @param timeout The time to wait for a connection. Normally passed the ThreadPool maxIdleTime.
      * @return Accepted Socket
      */

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
@@ -14,8 +14,10 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -252,7 +254,7 @@ public class BrowserMobHttpUtil {
         if (startsWithHttpOrHttps(httpRequest.getUri())) {
             try {
                 return getRawPathAndParamsFromUri(httpRequest.getUri());
-            } catch (URISyntaxException e) {
+            } catch (MalformedURLException e) {
                 // could not parse the URI, so fall through and return the URI as-is
             }
         }
@@ -289,12 +291,12 @@ public class BrowserMobHttpUtil {
      *
      * @param uriString the URI to parse, containing a scheme, host, port, path, and query parameters
      * @return the unescaped path and query parameters from the URI
-     * @throws URISyntaxException if the specified URI is invalid or cannot be parsed
+     * @throws MalformedURLException if the specified URI is invalid or cannot be parsed
      */
-    public static String getRawPathAndParamsFromUri(String uriString) throws URISyntaxException {
-        URI uri = new URI(uriString);
-        String path = uri.getRawPath();
-        String query = uri.getRawQuery();
+    public static String getRawPathAndParamsFromUri(String uriString) throws MalformedURLException {
+        URL uri = new URL(uriString);
+        String path = uri.getPath();
+        String query = uri.getQuery();
 
         if (query != null) {
             return path + '?' + query;

--- a/browsermob-core/src/main/resources/net/lightbody/bmp/proxy/jetty/http/jmx/mbean_en.properties
+++ b/browsermob-core/src/main/resources/net/lightbody/bmp/proxy/jetty/http/jmx/mbean_en.properties
@@ -158,7 +158,6 @@ HttpContext.removeAttribute(java.lang.String)   =Remove a context attribute.
 HttpContext.removeAttribute(java.lang.String)[0]=name:The attribute name.
 HttpContext.addHandler(net.lightbody.bmp.proxy.jetty.http.HttpHandler) = Add a HttpHandler instance to the context. When a request is serviced by the context, each handler is called in order until it is handled.
 HttpContext.addHandler(net.lightbody.bmp.proxy.jetty.http.HttpHandler)[0] = handler:The HttpHandler instance to add.
-HttpContext.addHandler(net.lightbody.bmp.proxy.jetty.http.HttpHandler) = Add a HttpHandler instance to the context. When a request is serviced by the context, each handler is called in order until it is handled.
 HttpContext.addHandler(int,net.lightbody.bmp.proxy.jetty.http.HttpHandler)[0] = index:The index within the context to insert the handler at.
 HttpContext.addHandler(int,net.lightbody.bmp.proxy.jetty.http.HttpHandler)[1] = handler:The HttpHandler instance to add.
 HttpContext.getHandler(int)       = Get a context HttpHandler.

--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/CookieTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/CookieTest.java
@@ -8,7 +8,6 @@ import net.lightbody.bmp.proxy.util.IOUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.cookie.BasicClientCookie;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;


### PR DESCRIPTION
If Request Url contains specific characters: 

http://test.com/test-page/index.html?optradio=edge&config={%22uri%22:%22google.com22,%22width%22:640,%22height%22:360,%22test%22:{%22topPanel%22:true,%22autoPlay%22:true}}

than Har log request with incorrect Uri: 

**http://test.comhttp://test.com**/test-page/index.html?optradio=edge&config={%22uri%22:%22google.com22,%22width%22:640,%22height%22:360,%22test%22:{%22topPanel%22:true,%22autoPlay%22:true}}