### PR TITLE
Update surefire settings to fix travis-ci build

### DIFF
--- a/browsermob-core-littleproxy/pom.xml
+++ b/browsermob-core-littleproxy/pom.xml
@@ -46,6 +46,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Xmx1g -XX:MaxPermSize=256m</argLine>
                     <systemProperties>
                         <bmp.use.littleproxy>true</bmp.use.littleproxy>
                     </systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19</version>
+                    <version>2.19.1</version>
+                    <configuration>
+                        <argLine>-Xmx1g -XX:MaxPermSize=256m</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I'm not sure why tests pass locally for me but fail in travis-ci due to OutOfMemoryError, but giving surefire plenty of memory seems to fix the issue.