### PR TITLE
Fix missing mimeType in HAR

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -523,7 +523,10 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
 
     protected void captureResponseMimeType(HttpResponse httpResponse) {
         String contentType = HttpHeaders.getHeader(httpResponse, HttpHeaders.Names.CONTENT_TYPE);
-        harEntry.getResponse().getContent().setMimeType(contentType);
+        // don't set the mimeType to null, since mimeType is a required field
+        if (contentType != null) {
+            harEntry.getResponse().getContent().setMimeType(contentType);
+        }
     }
 
     protected void captureResponseCookies(HttpResponse httpResponse) {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarContent.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarContent.java
@@ -6,7 +6,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class HarContent {
     private volatile long size;
     private volatile Long compression;
+
+    // mimeType is required; though it shouldn't be set to null, if it is, it still needs to be included to comply with the HAR spec
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     private volatile String mimeType = "";
+
     private volatile String text;
     private volatile String encoding;
     private volatile String comment = "";


### PR DESCRIPTION
This fixes issue #395. response.content.mimeType is now always included in the serialized HAR, even if it is null. Additionally, a missing Content-Type header will no longer set the mimeType to null.