### PR TITLE
Update LittleProxy version to beta2

### DIFF
--- a/mitm/pom.xml
+++ b/mitm/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.littleshoot</groupId>
             <artifactId>littleproxy</artifactId>
-            <version>1.1.0-beta1</version>
+            <version>1.1.0-beta2</version>
             <optional>true</optional>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <dependency>
                 <groupId>net.lightbody.bmp</groupId>
                 <artifactId>littleproxy</artifactId>
-                <version>1.1.0-beta-bmp-10</version>
+                <version>1.1.0-beta-bmp-11</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This updates the LP version used by MITM to the newly-released beta2, and browsermob-core-littleproxy to the newest BMP-LP build.