### PR TITLE
Incorporate LP fixes and use client hostname when generating certificates

### DIFF
--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpConnectHarCaptureFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpConnectHarCaptureFilter.java
@@ -12,7 +12,7 @@ import net.lightbody.bmp.core.har.HarResponse;
 import net.lightbody.bmp.core.har.HarTimings;
 import net.lightbody.bmp.filters.support.HttpConnectTiming;
 import net.lightbody.bmp.filters.util.HarCaptureUtil;
-import net.lightbody.bmp.util.BrowserMobHttpUtil;
+import net.lightbody.bmp.util.HttpUtil;
 import org.littleshoot.proxy.impl.ProxyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -346,7 +346,7 @@ public class HttpConnectHarCaptureFilter extends HttpsAwareFiltersAdapter implem
         if (resolvedAddress != null) {
             harEntry.setServerIPAddress(resolvedAddress.getHostAddress());
         } else {
-            String serverHost = BrowserMobHttpUtil.getHostFromRequest(modifiedHttpRequest);
+            String serverHost = HttpUtil.getHostFromRequest(modifiedHttpRequest);
             if (serverHost != null && !serverHost.isEmpty()) {
                 String resolvedAddress = ResolvedHostnameCacheFilter.getPreviouslyResolvedAddressForHost(serverHost);
                 if (resolvedAddress != null) {

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/HttpsAwareFiltersAdapter.java
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import net.lightbody.bmp.util.HttpUtil;
 import net.lightbody.bmp.util.BrowserMobHttpUtil;
 import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.impl.ProxyUtils;
@@ -59,7 +60,7 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
 
         // To get the full URL, we need to retrieve the Scheme, Host + Port, Path, and Query Params from the request.
         // If the request URI starts with http:// or https://, it is already a full URL and can be returned directly.
-        if (BrowserMobHttpUtil.startsWithHttpOrHttps(modifiedRequest.getUri())) {
+        if (HttpUtil.startsWithHttpOrHttps(modifiedRequest.getUri())) {
             return modifiedRequest.getUri();
         }
 
@@ -103,7 +104,7 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
             HostAndPort hostAndPort = HostAndPort.fromString(getHttpsRequestHostAndPort());
             serverHost = hostAndPort.getHostText();
         } else {
-            serverHost = BrowserMobHttpUtil.getHostFromRequest(modifiedRequest);
+            serverHost = HttpUtil.getHostFromRequest(modifiedRequest);
         }
         return serverHost;
     }
@@ -123,7 +124,7 @@ public class HttpsAwareFiltersAdapter extends HttpFiltersAdapter {
         if (isHttps()) {
             return getHttpsRequestHostAndPort();
         } else {
-            return BrowserMobHttpUtil.getHostAndPortFromRequest(modifiedRequest);
+            return HttpUtil.getHostAndPortFromRequest(modifiedRequest);
         }
     }
 

--- a/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RewriteUrlFilter.java
+++ b/browsermob-core-littleproxy/src/main/java/net/lightbody/bmp/filters/RewriteUrlFilter.java
@@ -5,6 +5,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import net.lightbody.bmp.util.HttpUtil;
 import net.lightbody.bmp.proxy.RewriteRule;
 import net.lightbody.bmp.util.BrowserMobHttpUtil;
 import org.littleshoot.proxy.impl.ProxyUtils;
@@ -64,7 +65,7 @@ public class RewriteUrlFilter extends HttpsAwareFiltersAdapter {
                 // with the rewritten URI. if not (for example, on HTTPS requests), strip the scheme, host, and port from
                 // the rewritten URL before replacing the URI on the request.
                 String uriFromRequest = httpRequest.getUri();
-                if (BrowserMobHttpUtil.startsWithHttpOrHttps(uriFromRequest)) {
+                if (HttpUtil.startsWithHttpOrHttps(uriFromRequest)) {
                     httpRequest.setUri(rewrittenUrl);
                 } else {
                     try {
@@ -88,7 +89,7 @@ public class RewriteUrlFilter extends HttpsAwareFiltersAdapter {
 
                 String originalHostAndPort = null;
                 try {
-                    originalHostAndPort = BrowserMobHttpUtil.getHostAndPortFromUri(originalUrl);
+                    originalHostAndPort = HttpUtil.getHostAndPortFromUri(originalUrl);
                 } catch (URISyntaxException e) {
                     // for some reason we couldn't determine the original host and port from the original URL. log a warning,
                     // and allow the Host header to be forcibly updated to the rewritten host and port.
@@ -100,7 +101,7 @@ public class RewriteUrlFilter extends HttpsAwareFiltersAdapter {
 
                 String modifiedHostAndPort = null;
                 try {
-                    modifiedHostAndPort = BrowserMobHttpUtil.getHostAndPortFromUri(rewrittenUrl);
+                    modifiedHostAndPort = HttpUtil.getHostAndPortFromUri(rewrittenUrl);
                 } catch (URISyntaxException e) {
                     log.warn("Unable to determine host and port from rewritten URL. Host header will not be updated.\n\tOriginal URL: {}\n\tRewritten URL: {}",
                             originalUrl,

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/util/BrowserMobHttpUtilTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/util/BrowserMobHttpUtilTest.groovy
@@ -45,7 +45,7 @@ class BrowserMobHttpUtilTest {
         ]
 
         uriToHostAndPort.each {uri, expectedHostAndPort ->
-            String parsedHostAndPort = BrowserMobHttpUtil.getHostAndPortFromUri(uri)
+            String parsedHostAndPort = HttpUtil.getHostAndPortFromUri(uri)
             assertEquals("Parsed host and port from URL did not match expected host and port for URL: " + uri, expectedHostAndPort, parsedHostAndPort)
         }
     }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
@@ -18,8 +18,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
@@ -195,52 +193,6 @@ public class BrowserMobHttpUtil {
     }
 
     /**
-     * Identify the host of an HTTP request. This method uses the URI of the request if possible, otherwise it attempts to find the host
-     * in the request headers.
-     *
-     * @param httpRequest HTTP request to parse the host from
-     * @return the host the request is connecting to, or null if no host can be found
-     */
-    public static String getHostFromRequest(HttpRequest httpRequest) {
-        // try to use the URI from the request first, if the URI starts with http:// or https://. checking for http/https avoids confusing
-        // java's URI class when the request is for a malformed URL like '//some-resource'.
-        String host = null;
-        if (startsWithHttpOrHttps(httpRequest.getUri())) {
-            try {
-                URI uri = new URI(httpRequest.getUri());
-                host = uri.getHost();
-            } catch (URISyntaxException e) {
-            }
-        }
-
-        // if there was no host in the URI, attempt to grab the host from the Host header
-        if (host == null || host.isEmpty()) {
-            host = parseHostHeader(httpRequest, false);
-        }
-
-        return host;
-    }
-
-    /**
-     * Gets the host and port from the specified request. Returns the host and port from the request URI if available,
-     * otherwise retrieves the host and port from the Host header.
-     *
-     * @param httpRequest HTTP request
-     * @return host and port of the request
-     */
-    public static String getHostAndPortFromRequest(HttpRequest httpRequest) {
-        if (startsWithHttpOrHttps(httpRequest.getUri())) {
-            try {
-                return getHostAndPortFromUri(httpRequest.getUri());
-            } catch (URISyntaxException e) {
-                // the URI could not be parsed, so return the host and port in the Host header
-            }
-        }
-
-        return parseHostHeader(httpRequest, true);
-    }
-
-    /**
      * Retrieves the raw (unescaped) path + query string from the specified request. The returned path will not include
      * the scheme, host, or port.
      *
@@ -250,7 +202,7 @@ public class BrowserMobHttpUtil {
      */
     public static String getRawPathAndParamsFromRequest(HttpRequest httpRequest) throws URISyntaxException {
         // if this request's URI contains a full URI (including scheme, host, etc.), strip away the non-path components
-        if (startsWithHttpOrHttps(httpRequest.getUri())) {
+        if (HttpUtil.startsWithHttpOrHttps(httpRequest.getUri())) {
             return getRawPathAndParamsFromUri(httpRequest.getUri());
         } else {
             // to provide consistent validation behavior for URIs that contain a scheme and those that don't, attempt to parse
@@ -259,28 +211,6 @@ public class BrowserMobHttpUtil {
 
             return httpRequest.getUri();
         }
-    }
-
-    /**
-     * Returns true if the string starts with http:// or https://.
-     *
-     * @param uri string to evaluate
-     * @return true if the string starts with http:// or https://
-     */
-    public static boolean startsWithHttpOrHttps(String uri) {
-        if (uri == null) {
-            return false;
-        }
-
-        // the scheme is case insensitive, according to RFC 7230, section 2.7.3:
-        /*
-            The scheme and host
-            are case-insensitive and normally provided in lowercase; all other
-            components are compared in a case-sensitive manner.
-        */
-        String lowercaseUri = uri.toLowerCase(Locale.US);
-
-        return lowercaseUri.startsWith("http://") || lowercaseUri.startsWith("https://");
     }
 
     /**
@@ -301,22 +231,6 @@ public class BrowserMobHttpUtil {
             return path + '?' + query;
         } else {
             return path;
-        }
-    }
-
-    /**
-     * Retrieves the host and port from the specified URI.
-     *
-     * @param uriString URI to retrieve the host and port from
-     * @return the host and port from the URI as a String
-     * @throws URISyntaxException if the specified URI is invalid or cannot be parsed
-     */
-    public static String getHostAndPortFromUri(String uriString) throws URISyntaxException {
-        URI uri = new URI(uriString);
-        if (uri.getPort() == -1) {
-            return uri.getHost();
-        } else {
-            return HostAndPort.fromParts(uri.getHost(), uri.getPort()).toString();
         }
     }
 
@@ -363,27 +277,4 @@ public class BrowserMobHttpUtil {
         }
     }
 
-    /**
-     * Retrieves the host and, optionally, the port from the specified request's Host header.
-     *
-     * @param httpRequest HTTP request
-     * @param includePort when true, include the port
-     * @return the host and, optionally, the port specified in the request's Host header
-     */
-    private static String parseHostHeader(HttpRequest httpRequest, boolean includePort) {
-        // this header parsing logic is adapted from ClientToProxyConnection#identifyHostAndPort.
-        List<String> hosts = httpRequest.headers().getAll(HttpHeaders.Names.HOST);
-        if (!hosts.isEmpty()) {
-            String hostAndPort = hosts.get(0);
-
-            if (includePort) {
-                return hostAndPort;
-            } else {
-                HostAndPort parsedHostAndPort = HostAndPort.fromString(hostAndPort);
-                return parsedHostAndPort.getHostText();
-            }
-        } else {
-            return null;
-        }
-    }
 }

--- a/mitm/README.md
+++ b/mitm/README.md
@@ -7,6 +7,8 @@ The MITM module uses "sensible" default settings that should work for the vast m
 ### LittleProxy (without BrowserMob Proxy)
 **Note:** The MITM module requires Java 7
 
+**Compatibility note:** If you are using LittleProxy 1.1.0-beta2, the latest compatible version of MITM is 2.1.0-beta-5. LittleProxy 1.1.0-beta3 and higher are compatible with MITM version 2.1.0-beta-6 and higher.
+
 To use MITM with standalone LittleProxy, add a dependency to the mitm module in your pom:
 
 ```xml
@@ -14,14 +16,14 @@ To use MITM with standalone LittleProxy, add a dependency to the mitm module in 
     <dependency>
         <groupId>org.littleshoot</groupId>
         <artifactId>littleproxy</artifactId>
-        <version>1.1.0-beta1</version>
+        <version>1.1.0-beta2</version>
     </dependency>
     
     <-- new dependency on the MITM module -->
     <dependency>
         <groupId>net.lightbody.bmp</groupId>
         <artifactId>mitm</artifactId>
-        <version>2.1.0-beta-4</version>
+        <version>2.1.0-beta-5</version>
     </dependency>
 ```
 

--- a/mitm/pom.xml
+++ b/mitm/pom.xml
@@ -12,10 +12,18 @@
     <artifactId>mitm</artifactId>
 
     <dependencies>
+        <!-- TODO: Depending on the BMP build of littleproxy due to a breaking change to MitmManager after
+             TODO: littleproxy 1.1.0-beta-2 was released to Central. After littleproxy 1.1.0-beta-3 is released,
+             TODO: restore this dependency to the stock littleproxy version. -->
+        <!--<dependency>-->
+            <!--<groupId>org.littleshoot</groupId>-->
+            <!--<artifactId>littleproxy</artifactId>-->
+            <!--<version>1.1.0-beta2</version>-->
+            <!--<optional>true</optional>-->
+        <!--</dependency>-->
         <dependency>
-            <groupId>org.littleshoot</groupId>
+            <groupId>net.lightbody.bmp</groupId>
             <artifactId>littleproxy</artifactId>
-            <version>1.1.0-beta2</version>
             <optional>true</optional>
         </dependency>
 

--- a/mitm/src/main/java/net/lightbody/bmp/util/HttpUtil.java
+++ b/mitm/src/main/java/net/lightbody/bmp/util/HttpUtil.java
@@ -1,0 +1,123 @@
+package net.lightbody.bmp.util;
+
+import com.google.common.net.HostAndPort;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Contains utility methods for netty {@link HttpRequest} and related objects.
+ */
+public class HttpUtil {
+    /**
+     * Identify the host of an HTTP request. This method uses the URI of the request if possible, otherwise it attempts to find the host
+     * in the request headers.
+     *
+     * @param httpRequest HTTP request to parse the host from
+     * @return the host the request is connecting to, or null if no host can be found
+     */
+    public static String getHostFromRequest(HttpRequest httpRequest) {
+        // try to use the URI from the request first, if the URI starts with http:// or https://. checking for http/https avoids confusing
+        // java's URI class when the request is for a malformed URL like '//some-resource'.
+        String host = null;
+        if (startsWithHttpOrHttps(httpRequest.getUri())) {
+            try {
+                URI uri = new URI(httpRequest.getUri());
+                host = uri.getHost();
+            } catch (URISyntaxException e) {
+            }
+        }
+
+        // if there was no host in the URI, attempt to grab the host from the Host header
+        if (host == null || host.isEmpty()) {
+            host = parseHostHeader(httpRequest, false);
+        }
+
+        return host;
+    }
+
+    /**
+     * Gets the host and port from the specified request. Returns the host and port from the request URI if available,
+     * otherwise retrieves the host and port from the Host header.
+     *
+     * @param httpRequest HTTP request
+     * @return host and port of the request
+     */
+    public static String getHostAndPortFromRequest(HttpRequest httpRequest) {
+        if (startsWithHttpOrHttps(httpRequest.getUri())) {
+            try {
+                return getHostAndPortFromUri(httpRequest.getUri());
+            } catch (URISyntaxException e) {
+                // the URI could not be parsed, so return the host and port in the Host header
+            }
+        }
+
+        return parseHostHeader(httpRequest, true);
+    }
+
+    /**
+     * Returns true if the string starts with http:// or https://.
+     *
+     * @param uri string to evaluate
+     * @return true if the string starts with http:// or https://
+     */
+    public static boolean startsWithHttpOrHttps(String uri) {
+        if (uri == null) {
+            return false;
+        }
+
+        // the scheme is case insensitive, according to RFC 7230, section 2.7.3:
+        /*
+            The scheme and host
+            are case-insensitive and normally provided in lowercase; all other
+            components are compared in a case-sensitive manner.
+        */
+        String lowercaseUri = uri.toLowerCase(Locale.US);
+
+        return lowercaseUri.startsWith("http://") || lowercaseUri.startsWith("https://");
+    }
+
+    /**
+     * Retrieves the host and port from the specified URI.
+     *
+     * @param uriString URI to retrieve the host and port from
+     * @return the host and port from the URI as a String
+     * @throws URISyntaxException if the specified URI is invalid or cannot be parsed
+     */
+    public static String getHostAndPortFromUri(String uriString) throws URISyntaxException {
+        URI uri = new URI(uriString);
+        if (uri.getPort() == -1) {
+            return uri.getHost();
+        } else {
+            return HostAndPort.fromParts(uri.getHost(), uri.getPort()).toString();
+        }
+    }
+
+    /**
+     * Retrieves the host and, optionally, the port from the specified request's Host header.
+     *
+     * @param httpRequest HTTP request
+     * @param includePort when true, include the port
+     * @return the host and, optionally, the port specified in the request's Host header
+     */
+    private static String parseHostHeader(HttpRequest httpRequest, boolean includePort) {
+        // this header parsing logic is adapted from ClientToProxyConnection#identifyHostAndPort.
+        List<String> hosts = httpRequest.headers().getAll(HttpHeaders.Names.HOST);
+        if (!hosts.isEmpty()) {
+            String hostAndPort = hosts.get(0);
+
+            if (includePort) {
+                return hostAndPort;
+            } else {
+                HostAndPort parsedHostAndPort = HostAndPort.fromString(hostAndPort);
+                return parsedHostAndPort.getHostText();
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/mitm/src/test/groovy/net/lightbody/bmp/mitm/ImpersonatingMitmManagerTest.groovy
+++ b/mitm/src/test/groovy/net/lightbody/bmp/mitm/ImpersonatingMitmManagerTest.groovy
@@ -1,5 +1,8 @@
 package net.lightbody.bmp.mitm
 
+import io.netty.handler.codec.http.DefaultFullHttpRequest
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpVersion
 import net.lightbody.bmp.mitm.keys.ECKeyGenerator
 import net.lightbody.bmp.mitm.keys.RSAKeyGenerator
 import net.lightbody.bmp.mitm.manager.ImpersonatingMitmManager
@@ -29,7 +32,8 @@ class ImpersonatingMitmManagerTest {
 
         when(mockSession.getPeerHost()).thenReturn("hostname")
 
-        SSLEngine clientSslEngine = mitmManager.clientSslEngineFor(mockSession)
+        def request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, "https://test.connection")
+        SSLEngine clientSslEngine = mitmManager.clientSslEngineFor(request, mockSession)
         assertNotNull(clientSslEngine)
     }
 
@@ -42,7 +46,8 @@ class ImpersonatingMitmManagerTest {
 
         when(mockSession.getPeerHost()).thenReturn("hostname")
 
-        SSLEngine clientSslEngine = mitmManager.clientSslEngineFor(mockSession)
+        def request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, "https://test.connection")
+        SSLEngine clientSslEngine = mitmManager.clientSslEngineFor(request, mockSession)
         assertNotNull(clientSslEngine)
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <dependency>
                 <groupId>net.lightbody.bmp</groupId>
                 <artifactId>littleproxy</artifactId>
-                <version>1.1.0-beta-bmp-11</version>
+                <version>1.1.0-beta-bmp-12</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR incorporates the latest fixes from LittleProxy master, one of which allows us to generate certificates for clients using the hostname included in the request, rather than the hostname of the upstream server.

Because the LP update includes a breaking change to the MitmManager class, this means the `mitm` module will not be compatible with stock littleproxy-1.1.0-beta2. Once a new LP version is released, `mitm`'s compatibility will be restored.