### PR TITLE
Make trustAllServers bypass all server certificate validations

### DIFF
--- a/mitm/src/main/java/net/lightbody/bmp/mitm/trustmanager/InsecureExtendedTrustManager.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/trustmanager/InsecureExtendedTrustManager.java
@@ -1,0 +1,149 @@
+package net.lightbody.bmp.mitm.trustmanager;
+
+import io.netty.util.internal.EmptyArrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * An {@link X509ExtendedTrustManager} and {@link javax.net.ssl.X509TrustManager} that will accept all server and client
+ * certificates. Before accepting a certificate, the InsecureExtendedTrustManager uses the default X509ExtendedTrustManager
+ * to determine if the certificate would otherwise be trusted, and logs a debug-level message if it is not trusted.
+ */
+public class InsecureExtendedTrustManager extends X509ExtendedTrustManager {
+    private static final Logger log = LoggerFactory.getLogger(InsecureExtendedTrustManager.class);
+
+    /**
+     * The default extended trust manager, which will be used to determine if certificates would otherwise be trusted.
+     */
+    protected static final X509ExtendedTrustManager DEFAULT_EXTENDED_TRUST_MANAGER = getDefaultExtendedTrustManager();
+
+    /**
+     * An {@link X509ExtendedTrustManager} that does no certificate validation whatsoever.
+     */
+    private static final X509ExtendedTrustManager NOOP_EXTENDED_TRUST_MANAGER = new X509ExtendedTrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return EmptyArrays.EMPTY_X509_CERTIFICATES;
+        }
+    };
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        try {
+            DEFAULT_EXTENDED_TRUST_MANAGER.checkClientTrusted(x509Certificates, s, socket);
+        } catch (CertificateException e) {
+            log.debug("Accepting an untrusted client certificate: {}", x509Certificates[0].getSubjectDN(), e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        try {
+            DEFAULT_EXTENDED_TRUST_MANAGER.checkServerTrusted(x509Certificates, s, socket);
+        } catch (CertificateException e) {
+            log.debug("Accepting an untrusted server certificate: {}", x509Certificates[0].getSubjectDN(), e);
+        }
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+        try {
+            DEFAULT_EXTENDED_TRUST_MANAGER.checkClientTrusted(x509Certificates, s, sslEngine);
+        } catch (CertificateException e) {
+            log.debug("Accepting an untrusted client certificate: {}", x509Certificates[0].getSubjectDN(), e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+        try {
+            DEFAULT_EXTENDED_TRUST_MANAGER.checkServerTrusted(x509Certificates, s, sslEngine);
+        } catch (CertificateException e) {
+            log.debug("Accepting an untrusted server certificate: {}", x509Certificates[0].getSubjectDN(), e);
+        }
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        try {
+            DEFAULT_EXTENDED_TRUST_MANAGER.checkClientTrusted(x509Certificates, s);
+        } catch (CertificateException e) {
+            log.debug("Accepting an untrusted client certificate: {}", x509Certificates[0].getSubjectDN(), e);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        try {
+            DEFAULT_EXTENDED_TRUST_MANAGER.checkServerTrusted(x509Certificates, s);
+        } catch (CertificateException e) {
+            log.debug("Accepting an untrusted server certificate: {}", x509Certificates[0].getSubjectDN(), e);
+        }
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return EmptyArrays.EMPTY_X509_CERTIFICATES;
+    }
+
+    /**
+     * Returns the JDK's default X509ExtendedTrustManager, or a no-op trust manager if the default cannot be found.
+     */
+    private static X509ExtendedTrustManager getDefaultExtendedTrustManager() {
+        TrustManagerFactory trustManagerFactory;
+        try {
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            // initialize the TrustManagerFactory with the default KeyStore
+            trustManagerFactory.init((KeyStore) null);
+        } catch (NoSuchAlgorithmException | KeyStoreException e) {
+            log.debug("Unable to initialize default TrustManagerFactory. Using no-op X509ExtendedTrustManager.", e);
+            return NOOP_EXTENDED_TRUST_MANAGER;
+        }
+
+        // find the X509ExtendedTrustManager in the list of registered trust managers
+        for (TrustManager tm : trustManagerFactory.getTrustManagers()) {
+            if (tm instanceof X509ExtendedTrustManager) {
+                return (X509ExtendedTrustManager) tm;
+            }
+        }
+
+        // no default X509ExtendedTrustManager found, so return a no-op
+        log.debug("No default X509ExtendedTrustManager found. Using no-op.");
+        return NOOP_EXTENDED_TRUST_MANAGER;
+    }
+}

--- a/mitm/src/main/java/net/lightbody/bmp/mitm/trustmanager/InsecureTrustManagerFactory.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/trustmanager/InsecureTrustManagerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 The Netty Project,
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package net.lightbody.bmp.mitm.trustmanager;
+
+import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
+
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.security.KeyStore;
+
+/**
+ * <b>Note:</b> This is a modified version of {@link io.netty.handler.ssl.util.InsecureTrustManagerFactory} from Netty
+ * 4.0.36. Unlike the netty version, this class returns an {@link X509ExtendedTrustManager} instead of an
+ * {@link javax.net.ssl.X509TrustManager} instance, which allows us to bypass additional certificate validations.
+ * <p/>
+ * An insecure {@link TrustManagerFactory} that trusts all X.509 certificates without any verification.
+ * <p>
+ * <strong>NOTE:</strong>
+ * Never use this {@link TrustManagerFactory} in production.
+ * It is purely for testing purposes, and thus it is very insecure.
+ * </p>
+ */
+public class InsecureTrustManagerFactory extends SimpleTrustManagerFactory {
+
+    public static final TrustManagerFactory INSTANCE = new InsecureTrustManagerFactory();
+
+    public static final X509ExtendedTrustManager tm = new InsecureExtendedTrustManager();
+
+    @Override
+    protected void engineInit(KeyStore keyStore) throws Exception {
+    }
+
+    @Override
+    protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws Exception {
+    }
+
+    @Override
+    protected TrustManager[] engineGetTrustManagers() {
+        return new TrustManager[]{tm};
+    }
+}

--- a/mitm/src/main/java/net/lightbody/bmp/mitm/util/SslUtil.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/util/SslUtil.java
@@ -7,7 +7,7 @@ import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import net.lightbody.bmp.mitm.trustmanager.InsecureTrustManagerFactory;
 import net.lightbody.bmp.mitm.TrustSource;
 import net.lightbody.bmp.mitm.exception.SslContextInitializationException;
 import org.slf4j.Logger;


### PR DESCRIPTION
This fixes issue #437. The trustAllServers option should now bypass all server certificate checks.