### PR TITLE
Add support for chained proxy authorization

### DIFF
--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/AutoAuthTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/AutoAuthTest.groovy
@@ -43,8 +43,6 @@ class AutoAuthTest extends MockServerTest {
         proxy.setTrustAllServers(true)
         proxy.start()
 
-        proxy.newHar()
-
         ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
             String responseBody = IOUtils.toStringAndClose(it.execute(new HttpGet("http://localhost:${mockServerPort}/basicAuthHttp")).getEntity().getContent());
             assertEquals("Did not receive expected response from mock server", "success", responseBody);

--- a/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/ChainedProxyAuthTest.groovy
+++ b/browsermob-core-littleproxy/src/test/groovy/net/lightbody/bmp/proxy/ChainedProxyAuthTest.groovy
@@ -1,0 +1,115 @@
+package net.lightbody.bmp.proxy
+
+import net.lightbody.bmp.BrowserMobProxy
+import net.lightbody.bmp.BrowserMobProxyServer
+import net.lightbody.bmp.proxy.auth.AuthType
+import net.lightbody.bmp.proxy.test.util.MockServerTest
+import net.lightbody.bmp.proxy.test.util.ProxyServerTest
+import net.lightbody.bmp.proxy.util.IOUtils
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpGet
+import org.junit.After
+import org.junit.Test
+import org.littleshoot.proxy.HttpProxyServer
+import org.littleshoot.proxy.ProxyAuthenticator
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer
+import org.mockserver.matchers.Times
+
+import static org.junit.Assert.assertEquals
+import static org.mockserver.model.HttpRequest.request
+import static org.mockserver.model.HttpResponse.response
+
+class ChainedProxyAuthTest extends MockServerTest {
+    BrowserMobProxy proxy
+
+    HttpProxyServer upstreamProxy
+
+    @After
+    void tearDown() {
+        if (proxy?.started) {
+            proxy.abort()
+        }
+
+        upstreamProxy?.abort()
+    }
+
+    @Test
+    void testAutoProxyAuthSuccessful() {
+        String proxyUser = "proxyuser"
+        String proxyPassword = "proxypassword"
+
+        upstreamProxy = DefaultHttpProxyServer.bootstrap()
+                .withProxyAuthenticator(new ProxyAuthenticator() {
+                    @Override
+                    boolean authenticate(String user, String password) {
+                        return proxyUser.equals(user) && proxyPassword.equals(password)
+                    }
+
+                    @Override
+                    String getRealm() {
+                        return "some-realm"
+                    }
+                })
+                .withPort(0)
+                .start()
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/proxyauth"),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(200)
+                .withBody("success"))
+
+        proxy = new BrowserMobProxyServer();
+        proxy.setChainedProxy(upstreamProxy.getListenAddress())
+        proxy.chainedProxyAuthorization(proxyUser, proxyPassword, AuthType.BASIC)
+        proxy.setTrustAllServers(true)
+        proxy.start()
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            String responseBody = IOUtils.toStringAndClose(it.execute(new HttpGet("https://localhost:${mockServerPort}/proxyauth")).getEntity().getContent());
+            assertEquals("Did not receive expected response from mock server", "success", responseBody);
+        };
+    }
+
+    @Test
+    void testAutoProxyAuthFailure() {
+        String proxyUser = "proxyuser"
+        String proxyPassword = "proxypassword"
+
+        upstreamProxy = DefaultHttpProxyServer.bootstrap()
+                .withProxyAuthenticator(new ProxyAuthenticator() {
+            @Override
+            boolean authenticate(String user, String password) {
+                return proxyUser.equals(user) && proxyPassword.equals(password)
+            }
+
+            @Override
+            String getRealm() {
+                return "some-realm"
+            }
+        })
+                .withPort(0)
+                .start()
+
+        mockServer.when(request()
+                .withMethod("GET")
+                .withPath("/proxyauth"),
+                Times.exactly(1))
+                .respond(response()
+                .withStatusCode(500)
+                .withBody("shouldn't happen"))
+
+        proxy = new BrowserMobProxyServer();
+        proxy.setChainedProxy(upstreamProxy.getListenAddress())
+        proxy.chainedProxyAuthorization(proxyUser, "wrongpassword", AuthType.BASIC)
+        proxy.setTrustAllServers(true)
+        proxy.start()
+
+        ProxyServerTest.getNewHttpClient(proxy.port).withCloseable {
+            CloseableHttpResponse response = it.execute(new HttpGet("https://localhost:${mockServerPort}/proxyauth"))
+            assertEquals("Expected to receive a Bad Gateway due to incorrect proxy authentication credentials", 502, response.getStatusLine().statusCode)
+        };
+    }
+}

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -304,6 +304,16 @@ public interface BrowserMobProxy {
     void stopAutoAuthorization(String domain);
 
     /**
+     * Enables chained proxy authorization using the Proxy-Authorization header described in RFC 7235, section 4.4 (https://tools.ietf.org/html/rfc7235#section-4.4).
+     * Currently, only {@link AuthType#BASIC} authentication is supported.
+     *
+     * @param username the username to use to authenticate with the chained proxy
+     * @param password the password to use to authenticate with the chained proxy
+     * @param authType the auth type to use (currently, must be BASIC)
+     */
+    void chainedProxyAuthorization(String username, String password, AuthType authType);
+
+    /**
      * Adds a rewrite rule for the specified URL-matching regular expression. If there are any existing rewrite rules, the new rewrite
      * rule will be applied last, after all other rewrite rules are applied. The specified urlPattern will be replaced with the specified
      * replacement expression. The urlPattern is treated as a Java regular expression and must be properly escaped (see {@link java.util.regex.Pattern}).

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -507,6 +507,11 @@ public class ProxyServer implements LegacyProxyServer, BrowserMobProxy {
         LOG.warn("Legacy ProxyServer implementation does not support stopping auto authorization");
     }
 
+    @Override
+    public void chainedProxyAuthorization(String username, String password, AuthType authType) {
+        LOG.warn("Legacy ProxyServer implementation does not support chained proxy authorization");
+    }
+
     public void endPage() {
         if (currentPage == null) {
             return;

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
@@ -11,6 +11,7 @@ import net.lightbody.bmp.exception.UnsupportedCharsetException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -277,4 +278,19 @@ public class BrowserMobHttpUtil {
         }
     }
 
+    /**
+     * Base64-encodes the specified username and password for Basic Authorization for HTTP requests or upstream proxy
+     * authorization. The format of Basic auth is "username:password" as a base64 string.
+     *
+     * @param username username to encode
+     * @param password password to encode
+     * @return a base-64 encoded string containing <code>username:password</code>
+     */
+    public static String base64EncodeBasicCredentials(String username, String password) {
+        String credentialsToEncode = username + ':' + password;
+        // using UTF-8, which is the modern de facto standard, and which retains compatibility with US_ASCII for ASCII characters,
+        // as required by RFC 7616, section 3: http://tools.ietf.org/html/rfc7617#section-3
+        byte[] credentialsAsUtf8Bytes = credentialsToEncode.getBytes(StandardCharsets.UTF_8);
+        return DatatypeConverter.printBase64Binary(credentialsAsUtf8Bytes);
+    }
 }

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/ProxyManager.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/ProxyManager.java
@@ -8,9 +8,11 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import net.lightbody.bmp.BrowserMobProxy;
 import net.lightbody.bmp.BrowserMobProxyServer;
 import net.lightbody.bmp.exception.ProxyExistsException;
 import net.lightbody.bmp.exception.ProxyPortsExhaustedException;
+import net.lightbody.bmp.proxy.auth.AuthType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,6 +152,13 @@ public class ProxyManager {
         }
 
         if (options != null) {
+            // this is a short-term work-around for Proxy Auth in the REST API until the upcoming REST API refactor
+            String proxyUsername = options.remove("proxyUsername");
+            String proxyPassword = options.remove("proxyPassword");
+            if (proxyUsername != null && proxyPassword != null) {
+                ((BrowserMobProxy)proxy).chainedProxyAuthorization(proxyUsername, proxyPassword, AuthType.BASIC);
+            }
+
             LOG.debug("Apply options `{}` to new ProxyServer...", options);
             proxy.setOptions(options);
         }

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -74,6 +74,9 @@ public class ProxyResource {
         String systemProxyHost = System.getProperty("http.proxyHost");
         String systemProxyPort = System.getProperty("http.proxyPort");
         String httpProxy = request.param("httpProxy");
+        String proxyUsername = request.param("proxyUsername");
+        String proxyPassword = request.param("proxyPassword");
+
         Hashtable<String, String> options = new Hashtable<String, String>();
 
         // If the upstream proxy is specified via query params that should override any default system level proxy.
@@ -81,6 +84,12 @@ public class ProxyResource {
             options.put("httpProxy", httpProxy);
         } else if ((systemProxyHost != null) && (systemProxyPort != null)) {
             options.put("httpProxy", String.format("%s:%s", systemProxyHost, systemProxyPort));
+        }
+
+        // this is a short-term work-around for Proxy Auth in the REST API until the upcoming REST API refactor
+        if (proxyUsername != null && proxyPassword != null) {
+            options.put("proxyUsername", proxyUsername);
+            options.put("proxyPassword", proxyPassword);
         }
 
         String paramBindAddr = request.param("bindAddress");


### PR DESCRIPTION
This PR enables Basic proxy authentication support in embedded mode and in standalone via the REST API.

The REST API now supports two new query params when creating a new proxy: `proxyUsername` and `proxyPassword`. If they are present, they will be used when authenticating with upstream proxies via the Proxy-Authorization header. (Note that this is a temporary solution until the new REST API is ready.)