### PR TITLE
Fix null TrustStore exception

### DIFF
--- a/mitm/src/main/java/net/lightbody/bmp/mitm/TrustSource.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/TrustSource.java
@@ -47,7 +47,7 @@ public class TrustSource {
      * Creates a TrustSource that contains no trusted certificates. For public use, see {@link #empty()}.
      */
     protected TrustSource() {
-        this(new X509Certificate[0]);
+        this(TrustUtil.EMPTY_CERTIFICATE_ARRAY);
     }
 
     /**
@@ -58,10 +58,10 @@ public class TrustSource {
      */
     protected TrustSource(X509Certificate... trustedCAs) {
         if (trustedCAs == null) {
-            throw new IllegalArgumentException("Trusted CAs cannot be null");
+            this.trustedCAs = TrustUtil.EMPTY_CERTIFICATE_ARRAY;
+        } else {
+            this.trustedCAs = trustedCAs;
         }
-
-        this.trustedCAs = trustedCAs;
     }
 
     /**

--- a/mitm/src/main/java/net/lightbody/bmp/mitm/util/TrustUtil.java
+++ b/mitm/src/main/java/net/lightbody/bmp/mitm/util/TrustUtil.java
@@ -45,6 +45,11 @@ public class TrustUtil {
     private static final String DEFAULT_TRUSTED_CA_RESOURCE = "/cacerts.pem";
 
     /**
+     * Empty X509 certificate array, useful for indicating an empty root CA trust store.
+     */
+    public static final X509Certificate[] EMPTY_CERTIFICATE_ARRAY = new X509Certificate[0];
+
+    /**
      * Security provider used to transform PEM files into Certificates.
      * TODO: Modify the architecture of TrustUtil and TrustSource so that they do not need a hard-coded SecurityProviderTool.
      */
@@ -58,7 +63,13 @@ public class TrustUtil {
         public X509Certificate[] get() {
             X509TrustManager defaultTrustManager = getDefaultJavaTrustManager();
 
-            return defaultTrustManager.getAcceptedIssuers();
+            X509Certificate[] defaultJavaTrustedCerts = defaultTrustManager.getAcceptedIssuers();
+
+            if (defaultJavaTrustedCerts != null) {
+                return defaultJavaTrustedCerts;
+            } else {
+                return EMPTY_CERTIFICATE_ARRAY;
+            }
         }
     });
 


### PR DESCRIPTION
This PR fixes an issue that occurs when the default Java trust store contains no trusted certificate entries.