### PR TITLE
Fix for HAR cookie capture

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -3,8 +3,6 @@ package net.lightbody.bmp.filters;
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.Cookie;
-import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
@@ -12,6 +10,9 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import net.lightbody.bmp.core.har.Har;
 import net.lightbody.bmp.core.har.HarCookie;
 import net.lightbody.bmp.core.har.HarEntry;
@@ -25,8 +26,8 @@ import net.lightbody.bmp.exception.UnsupportedCharsetException;
 import net.lightbody.bmp.filters.support.HttpConnectTiming;
 import net.lightbody.bmp.filters.util.HarCaptureUtil;
 import net.lightbody.bmp.proxy.CaptureType;
-import net.lightbody.bmp.util.BrowserMobProxyUtil;
 import net.lightbody.bmp.util.BrowserMobHttpUtil;
+import net.lightbody.bmp.util.BrowserMobProxyUtil;
 import net.sf.uadetector.ReadableUserAgent;
 import org.littleshoot.proxy.impl.ProxyUtils;
 import org.slf4j.Logger;
@@ -369,13 +370,13 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
             return;
         }
 
-        Set<Cookie> cookies = CookieDecoder.decode(cookieHeader);
+        Set<Cookie> cookies = ServerCookieDecoder.LAX.decode(cookieHeader);
 
         for (Cookie cookie : cookies) {
             HarCookie harCookie = new HarCookie();
 
-            harCookie.setName(cookie.getName());
-            harCookie.setValue(cookie.getValue());
+            harCookie.setName(cookie.name());
+            harCookie.setValue(cookie.value());
 
             harEntry.getRequest().getCookies().add(harCookie);
         }
@@ -536,25 +537,26 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
         }
 
         for (String setCookieHeader : setCookieHeaders) {
-            Set<Cookie> cookies = CookieDecoder.decode(setCookieHeader);
-            // really there should only be one cookie per Set-Cookie header
-            for (Cookie cookie : cookies) {
-                HarCookie harCookie = new HarCookie();
-
-                harCookie.setName(cookie.getName());
-                harCookie.setValue(cookie.getValue());
-                harCookie.setComment(cookie.getComment());
-                harCookie.setDomain(cookie.getDomain());
-                harCookie.setHttpOnly(cookie.isHttpOnly());
-                harCookie.setPath(cookie.getPath());
-                harCookie.setSecure(cookie.isSecure());
-                if (cookie.maxAge() > 0) {
-                    // cookie.maxAge() returns the max age of the cookie in seconds; java.util.Date requires milliseconds
-                    harCookie.setExpires(new Date(System.currentTimeMillis() + cookie.maxAge() / 1000L));
-                }
-
-                harEntry.getResponse().getCookies().add(harCookie);
+            Cookie cookie = ClientCookieDecoder.LAX.decode(setCookieHeader);
+            if (cookie == null) {
+                return;
             }
+
+            HarCookie harCookie = new HarCookie();
+
+            harCookie.setName(cookie.name());
+            harCookie.setValue(cookie.value());
+            // comment is no longer supported in the netty ClientCookieDecoder
+            harCookie.setDomain(cookie.domain());
+            harCookie.setHttpOnly(cookie.isHttpOnly());
+            harCookie.setPath(cookie.path());
+            harCookie.setSecure(cookie.isSecure());
+            if (cookie.maxAge() > 0) {
+                // cookie.maxAge() returns the max age of the cookie in seconds; java.util.Date requires milliseconds
+                harCookie.setExpires(new Date(System.currentTimeMillis() + cookie.maxAge() / 1000L));
+            }
+
+            harEntry.getResponse().getCookies().add(harCookie);
         }
     }
 


### PR DESCRIPTION
This PR fixes the cookie capture issues reported in #311. It also updates the cookie decoding code to use Netty's new cookie decoders, instead of the deprecated decoder we had been using.