### PR TITLE
Support getting read and write bandwidth limits

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxy.java
@@ -238,11 +238,21 @@ public interface BrowserMobProxy {
     void setReadBandwidthLimit(long bytesPerSecond);
 
     /**
+     * Returns the current bandwidth limit for reading, in bytes per second.
+     */
+    long getReadBandwidthLimit();
+
+    /**
      * Sets the maximum bandwidth to consume when sending requests to servers.
      *
      * @param bytesPerSecond maximum bandwidth, in bytes per second
      */
     void setWriteBandwidthLimit(long bytesPerSecond);
+
+    /**
+     * Returns the current bandwidth limit for writing, in bytes per second.
+     */
+    long getWriteBandwidthLimit();
 
     /**
      * The minimum amount of time that will elapse between the time the proxy begins receiving a response from the server and the time the

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -582,7 +582,11 @@ public class BrowserMobProxyServer implements BrowserMobProxy {
         if (isStarted()) {
             proxyServer.setThrottle(this.readBandwidthLimitBps, this.writeBandwidthLimitBps);
         }
+    }
 
+    @Override
+    public long getReadBandwidthLimit() {
+        return readBandwidthLimitBps;
     }
 
     @Override
@@ -592,6 +596,11 @@ public class BrowserMobProxyServer implements BrowserMobProxy {
         if (isStarted()) {
             proxyServer.setThrottle(this.readBandwidthLimitBps, this.writeBandwidthLimitBps);
         }
+    }
+
+    @Override
+    public long getWriteBandwidthLimit() {
+        return writeBandwidthLimitBps;
     }
 
     public void endPage() {

--- a/browsermob-legacy/src/main/java/net/lightbody/bmp/BrowserMobProxyServerLegacyAdapter.java
+++ b/browsermob-legacy/src/main/java/net/lightbody/bmp/BrowserMobProxyServerLegacyAdapter.java
@@ -147,6 +147,32 @@ public class BrowserMobProxyServerLegacyAdapter extends BrowserMobProxyServer im
         public void setUpstreamMaxKB(long upstreamMaxKB) {
             BrowserMobProxyServerLegacyAdapter.this.setReadLimitKbps(upstreamMaxKB);
         }
+
+        @Override
+        public long getMaxUpstreamKB() {
+            return BrowserMobProxyServerLegacyAdapter.this.getReadBandwidthLimit() / 1024L;
+        }
+
+        /**
+         * @deprecated This method is no longer supported and does not return correct values.
+         */
+        @Override
+        public long getRemainingUpstreamKB() {
+            return super.getRemainingUpstreamKB();
+        }
+
+        @Override
+        public long getMaxDownstreamKB() {
+            return BrowserMobProxyServerLegacyAdapter.this.getWriteBandwidthLimit() / 1024L;
+        }
+
+        /**
+         * @deprecated This method is no longer supported and does not return correct values.
+         */
+        @Override
+        public long getRemainingDownstreamKB() {
+            return super.getRemainingDownstreamKB();
+        }
     }
 
     @Override

--- a/browsermob-legacy/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
+++ b/browsermob-legacy/src/main/java/net/lightbody/bmp/proxy/ProxyServer.java
@@ -465,12 +465,22 @@ public class ProxyServer implements LegacyProxyServer, BrowserMobProxy {
 
     @Override
     public void setReadBandwidthLimit(long bytesPerSecond) {
-        getStreamManager().setDownstreamKbps(bytesPerSecond / 1024);
+        getStreamManager().setDownstreamKbps(bytesPerSecond / 1024L);
+    }
+
+    @Override
+    public long getReadBandwidthLimit() {
+        return getStreamManager().getMaxDownstreamKB() * 1024L;
     }
 
     @Override
     public void setWriteBandwidthLimit(long bytesPerSecond) {
-        getStreamManager().setUpstreamKbps(bytesPerSecond / 1024);
+        getStreamManager().setUpstreamKbps(bytesPerSecond / 1024L);
+    }
+
+    @Override
+    public long getWriteBandwidthLimit() {
+        return getStreamManager().getMaxUpstreamKB() * 1024L;
     }
 
     @Override


### PR DESCRIPTION
This PR adds getter methods for bandwidth limits to the BrowserMobProxy interface. It should also fix issue #458.