### PR TITLE
Fix IP address caching in HarCaptureFilter

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/filters/HarCaptureFilter.java
@@ -641,7 +641,10 @@ public class HarCaptureFilter extends HttpsAwareFiltersAdapter {
             if (resolvedAddress != null) {
                 harEntry.setServerIPAddress(resolvedAddress);
             } else {
-                log.warn("Unable to find cached IP address for host: {}. IP address in HAR entry will be blank.", serverHost);
+                // the resolvedAddress may be null if the ResolvedHostnameCacheFilter has expired the entry (which is unlikely),
+                // or in the far more common case that the proxy is using a chained proxy to connect to connect to the
+                // remote host. since the chained proxy handles IP address resolution, the IP address in the HAR must be blank.
+                log.trace("Unable to find cached IP address for host: {}. IP address in HAR entry will be blank.", serverHost);
             }
         } else {
             log.warn("Unable to identify host from request uri: {}", httpRequest.getUri());


### PR DESCRIPTION
This fixes the issue reported in #484, and also fixes the IP address caching in the HarCaptureFilter, which was expiring IP addresses too soon.