### PR TITLE
Making netty 4.1 the default in standalone mode

### DIFF
--- a/browsermob-dist/pom.xml
+++ b/browsermob-dist/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <zip.name>${project.parent.artifactId}-${project.version}</zip.name>
+        <netty.version>${netty-4.1.version}</netty.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,8 @@
         <groovy-eclipse-batch.version>2.4.3-01</groovy-eclipse-batch.version>
 
         <netty.version>4.0.39.Final</netty.version>
+        <!-- netty 4.1 version to use for browsermob-dist and when using the netty-4.1 profile -->
+        <netty-4.1.version>4.1.3.Final</netty-4.1.version>
 
         <bouncycastle.version>1.54</bouncycastle.version>
     </properties>
@@ -468,7 +470,7 @@
         <profile>
             <id>netty-4.1</id>
             <properties>
-                <netty.version>4.1.3.Final</netty.version>
+                <netty.version>${netty-4.1.version}</netty.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
In order to increase testing of BMP with netty 4.1, I'm setting the default netty verison in standalone mode to 4.1.