### PR TITLE
Upgraded to latest netty to avoid memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <groovy.version>2.4.7</groovy.version>
         <groovy-eclipse-batch.version>2.4.3-01</groovy-eclipse-batch.version>
 
-        <netty.version>4.0.39.Final</netty.version>
+        <netty.version>4.0.40.Final</netty.version>
         <!-- netty 4.1 version to use for browsermob-dist and when using the netty-4.1 profile -->
-        <netty-4.1.version>4.1.3.Final</netty-4.1.version>
+        <netty-4.1.version>4.1.4.Final</netty-4.1.version>
 
         <bouncycastle.version>1.54</bouncycastle.version>
     </properties>
@@ -245,7 +245,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.0.87-beta</version>
+                <version>2.0.95-beta</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Netty recommends upgrading due to a memory leak, so I'll get this out there.