### PR TITLE
Added simple 'version' flag to command-line launcher

### DIFF
--- a/browsermob-dist/src/main/java/net/lightbody/bmp/proxy/Main.java
+++ b/browsermob-dist/src/main/java/net/lightbody/bmp/proxy/Main.java
@@ -39,6 +39,11 @@ public class Main {
     public static void main(String[] args) {
         configureLogging();
 
+        if (args.length > 0 && "--version".equals(args[0])) {
+            System.out.println("BrowserMob Proxy " + BrowserMobProxyUtil.getVersionString());
+            System.exit(0);
+        }
+
         final Injector injector = Guice.createInjector(new ConfigModule(args), new JettyModule(), new SitebricksModule() {
             @Override
             protected void configureSitebricks() {


### PR DESCRIPTION
Adds a simple `--version` flag to the command-line to address issue #565.