### PR TITLE
Remove uadetector

### DIFF
--- a/browsermob-core/pom.xml
+++ b/browsermob-core/pom.xml
@@ -79,12 +79,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.sf.uadetector</groupId>
-            <artifactId>uadetector-resources</artifactId>
-            <version>2014.10</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -43,8 +43,8 @@ import net.lightbody.bmp.proxy.Whitelist;
 import net.lightbody.bmp.proxy.auth.AuthType;
 import net.lightbody.bmp.proxy.dns.AdvancedHostResolver;
 import net.lightbody.bmp.proxy.dns.DelegatingHostResolver;
-import net.lightbody.bmp.util.BrowserMobProxyUtil;
 import net.lightbody.bmp.util.BrowserMobHttpUtil;
+import net.lightbody.bmp.util.BrowserMobProxyUtil;
 import org.littleshoot.proxy.ChainedProxy;
 import org.littleshoot.proxy.ChainedProxyAdapter;
 import org.littleshoot.proxy.ChainedProxyManager;
@@ -461,9 +461,6 @@ public class BrowserMobProxyServer implements BrowserMobProxy {
 
     @Override
     public Har newHar(String initialPageRef, String initialPageTitle) {
-        // eagerly initialize the User Agent String Parser, since it will be needed for the HAR
-        BrowserMobProxyUtil.getUserAgentStringParser();
-
         Har oldHar = getHar();
 
         addHarCaptureFilter();

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobProxyUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobProxyUtil.java
@@ -7,8 +7,6 @@ import net.lightbody.bmp.core.har.HarEntry;
 import net.lightbody.bmp.core.har.HarLog;
 import net.lightbody.bmp.core.har.HarPage;
 import net.lightbody.bmp.mitm.exception.UncheckedIOException;
-import net.sf.uadetector.UserAgentStringParser;
-import net.sf.uadetector.service.UADetectorServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,11 +31,6 @@ public class BrowserMobProxyUtil {
     private static final String UNKNOWN_VERSION_STRING = "UNKNOWN-VERSION";
 
     /**
-     * Singleton User Agent parser.
-     */
-    private static volatile UserAgentStringParser parser;
-
-    /**
      * Singleton version string loader.
      */
     private static final Supplier<String> version = Suppliers.memoize(new Supplier<String>() {
@@ -46,27 +39,6 @@ public class BrowserMobProxyUtil {
             return readVersionFileOnClasspath();
         }
     });
-
-    private static final Object PARSER_INIT_LOCK = new Object();
-
-    /**
-     * Retrieve the User Agent String Parser. Create the parser if it has not yet been initialized.
-     * 
-     * @return singleton UserAgentStringParser object
-     */
-    public static UserAgentStringParser getUserAgentStringParser() {
-        if (parser == null) {
-            synchronized (PARSER_INIT_LOCK) {
-                if (parser == null) {
-                    // using resourceModuleParser for now because user-agent-string.info no longer exists. the updating
-                    // parser will get incorrect data and wipe out its entire user agent repository.
-                    parser = UADetectorServiceFactory.getResourceModuleParser();
-                }
-            }
-        }
-
-        return parser;
-    }
 
     /**
      * Copies {@link HarEntry} and {@link HarPage} references from the specified har to a new har copy, up to and including

--- a/browsermob-legacy/src/test/java/net/lightbody/bmp/proxy/HarTest.java
+++ b/browsermob-legacy/src/test/java/net/lightbody/bmp/proxy/HarTest.java
@@ -85,27 +85,6 @@ public class HarTest extends LocalServerTest {
     }
 
 	@Test
-	public void testHarContainsUserAgent() throws IOException, InterruptedException {
-		proxy.setCaptureHeaders(true);
-		proxy.newHar("testHarContainsUserAgent");
-
-		HttpGet httpGet = new HttpGet(getLocalServerHostnameAndPort() + "/echo");
-		httpGet.setHeader("User-Agent", "Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/31.0");
-		EntityUtils.consumeQuietly(client.execute(httpGet).getEntity());
-
-        Thread.sleep(500);
-		Har har = proxy.getHar();
-		assertNotNull("Har is null", har);
-		HarLog log = har.getLog();
-		assertNotNull("Log is null", log);
-		HarNameVersion harNameVersion = log.getBrowser();
-		assertNotNull("HarNameVersion is null", harNameVersion);
-
-		assertEquals("Expected browser to be Firefox", "Firefox", harNameVersion.getName());
-		assertEquals("Expected browser version to be 31.0", "31.0", harNameVersion.getVersion());
-	}
-
-	@Test
 	public void testThatProxyCanCaptureBodyInHar() throws IOException, InterruptedException {
 		proxy.setCaptureContent(true);
 		proxy.newHar("Test");


### PR DESCRIPTION
This removes the dependency on uadetector, which is no longer being updated, and seems to cause more problems than it solves (e.g. #557). 

It also makes little sense for BMP to put the browser version in the HarLog object. As an alternative, the User-Agent header can be captured like any other header using the REQUEST_HEADERS CaptureType, which will also move the user agent info to the request level, which makes much more sense for BMP.