### PR TITLE
Deprecate dnsjava

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/client/ClientUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/client/ClientUtil.java
@@ -42,6 +42,7 @@ public class ClientUtil {
      * calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.AdvancedHostResolver)}.
      *
      * @return a new DnsJavaResolver
+     * @deprecated The dnsjava resolver has been deprecated in favor of the standard JVM resolver and will be removed in BMP >2.1.
      */
     public static AdvancedHostResolver createDnsJavaResolver() {
         return new DnsJavaResolver();
@@ -53,6 +54,7 @@ public class ClientUtil {
      * Can be used when calling {@link net.lightbody.bmp.BrowserMobProxy#setHostNameResolver(net.lightbody.bmp.proxy.dns.AdvancedHostResolver)}.
      *
      * @return a new ChainedHostResolver that resolves addresses first using a DnsJavaResolver, then using a NativeCacheManipulatingResolver
+     * @deprecated The dnsjava resolver has been deprecated in favor of the standard JVM resolver and will be removed in BMP >2.1.
      */
     public static AdvancedHostResolver createDnsJavaWithNativeFallbackResolver() {
         return new ChainedHostResolver(ImmutableList.of(new DnsJavaResolver(), new NativeCacheManipulatingResolver()));
@@ -74,7 +76,7 @@ public class ClientUtil {
      * Creates a Selenium Proxy object from the BrowserMobProxy instance, using the specified connectableAddress as the Selenium Proxy object's
      * proxy address. Determines the port using {@link net.lightbody.bmp.BrowserMobProxy#getPort()}. The BrowserMobProxy must be started.
      *
-     * @param browserMobProxy started BrowserMobProxy instance to read the port from
+     * @param browserMobProxy    started BrowserMobProxy instance to read the port from
      * @param connectableAddress the network address the Selenium Proxy will use to reach this BrowserMobProxy instance
      * @return a Selenium Proxy instance, configured to use the BrowserMobProxy instance as its proxy server
      * @throws java.lang.IllegalStateException if the proxy has not been started.
@@ -105,6 +107,7 @@ public class ClientUtil {
      * Attempts to retrieve a "connectable" address for this device that other devices on the network can use to connect to a local proxy.
      * This is a "reasonable guess" that is suitable in many (but not all) common scenarios.
      * TODO: define the algorithm used to discover a "connectable" local host
+     *
      * @return a "reasonable guess" at an address that can be used by other machines on the network to reach this host
      */
     public static InetAddress getConnectableAddress() {

--- a/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/DnsJavaResolver.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/proxy/dns/DnsJavaResolver.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * An {@link net.lightbody.bmp.proxy.dns.AdvancedHostResolver} that uses dnsjava to perform DNS lookups. This implementation provides full
  * cache manipulation capabilities.
+ *
+ * @deprecated The dnsjava resolver has been deprecated in favor of the standard JVM resolver and will be removed in BMP >2.1.
  */
 public class DnsJavaResolver extends AbstractHostNameRemapper implements AdvancedHostResolver {
     private static final Logger log = LoggerFactory.getLogger(DnsJavaResolver.class);

--- a/browsermob-core/src/test/java/net/lightbody/bmp/proxy/dns/AdvancedHostResolverTest.java
+++ b/browsermob-core/src/test/java/net/lightbody/bmp/proxy/dns/AdvancedHostResolverTest.java
@@ -28,7 +28,7 @@ public class AdvancedHostResolverTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {DnsJavaResolver.class}, {NativeResolver.class}, {NativeCacheManipulatingResolver.class}, {ChainedHostResolver.class}
+                {NativeResolver.class}, {NativeCacheManipulatingResolver.class}, {ChainedHostResolver.class}
         });
     }
 
@@ -37,7 +37,7 @@ public class AdvancedHostResolverTest {
     public AdvancedHostResolverTest(Class<AdvancedHostResolver> resolverClass) throws IllegalAccessException, InstantiationException {
         // this is a hacky way to allow us to test the ChainedHostResolver, even though it doesn't have a no-arg constructor
         if (resolverClass.equals(ChainedHostResolver.class)) {
-            this.resolver = new ChainedHostResolver(ImmutableList.of(new DnsJavaResolver(), new NativeResolver(), new NativeCacheManipulatingResolver()));
+            this.resolver = new ChainedHostResolver(ImmutableList.of(new NativeResolver(), new NativeCacheManipulatingResolver()));
         } else {
             this.resolver = resolverClass.newInstance();
         }
@@ -96,18 +96,11 @@ public class AdvancedHostResolverTest {
 
         // disabling this assert to prevent test failures on systems without ipv6 access, or when the DNS server does not return IPv6 addresses
         //assertTrue("Expected to find at least one IPv6 address for www.google.com", foundIPv6);
-        // update: since the dnsjava resolver now returns ipv6 addresses *only if there are no ipv4 addresses*, it will generally not return
-        // any ipv6 addresses for most hostnames
 
     }
 
     @Test
     public void testResolveLocalhost() {
-        // DnsJavaResolver cannot resolve localhost, since it does not look up entries in the hosts file
-        if (resolver.getClass() == DnsJavaResolver.class) {
-            return;
-        }
-
         Collection<InetAddress> addresses = resolver.resolve("localhost");
 
         assertNotNull("Collection of resolved addresses should never be null", addresses);


### PR DESCRIPTION
This PR officially deprecates dnsjava support. Dnsjava usage with BMP appears to be rather low, and removing dnsjava support allows me to focus on other parts of the proxy.

dnsjava will be removed in the next significant release, either 2.2.x or 3.0.