### PR TITLE
Correctly recognize "application/<anything>+json" content types as text.

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
@@ -133,7 +133,8 @@ public class BrowserMobHttpUtil {
                 contentType.startsWith("application/javascript")  ||
                 contentType.startsWith("application/json")  ||
                 contentType.startsWith("application/xml")  ||
-                contentType.startsWith("application/xhtml+xml")
+                contentType.startsWith("application/xhtml+xml") ||
+                contentType.startsWith("application/") && contentType.endsWith("+json")
                 );
     }
 

--- a/browsermob-legacy/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/browsermob-legacy/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -1090,12 +1090,14 @@ public class BrowserMobHttpClient {
     }
 
 	private boolean hasTextualContent(String contentType) {
-		return contentType != null && contentType.startsWith("text/") ||
+		return contentType != null && (contentType.startsWith("text/") ||
 				contentType.startsWith("application/x-javascript") ||
 				contentType.startsWith("application/javascript")  ||
 				contentType.startsWith("application/json")  ||
 				contentType.startsWith("application/xml")  ||
-				contentType.startsWith("application/xhtml+xml");
+				contentType.startsWith("application/xhtml+xml") ||
+				contentType.startsWith("application/") && contentType.endsWith("+json")
+        );
 	}
 
 	private void setBinaryContentOfEntry(HarEntry entry, ByteArrayOutputStream copy) {


### PR DESCRIPTION
Previously "application/something-v1+json" (a common style for REST interfaces) was not recognized as text and thus response bodies were not recorded. 

Also fixes what I think was an operator precedence bug.