### PR TITLE
Fixing credentials leak

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -352,7 +352,9 @@ public class BrowserMobProxyServer implements BrowserMobProxy {
                             public void filterRequest(HttpObject httpObject) {
                                 String chainedProxyAuth = chainedProxyCredentials;
                                 if (chainedProxyAuth != null) {
-                                    if (httpObject instanceof HttpRequest) {
+                                    if (httpObject instanceof HttpRequest && (
+                                            ((HttpRequest) httpObject).method().toString().equals("CONNECT") ||
+                                                    !((HttpRequest) httpObject).uri().toString().startsWith("/"))) {
                                         HttpHeaders.addHeader((HttpRequest)httpObject, HttpHeaders.Names.PROXY_AUTHORIZATION, "Basic " + chainedProxyAuth);
                                     }
                                 }

--- a/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/BrowserMobProxyServer.java
@@ -352,7 +352,7 @@ public class BrowserMobProxyServer implements BrowserMobProxy {
                             public void filterRequest(HttpObject httpObject) {
                                 String chainedProxyAuth = chainedProxyCredentials;
                                 if (chainedProxyAuth != null) {
-                                    if (httpObject instanceof HttpRequest) {
+                                    if (httpObject instanceof HttpRequest && ((HttpRequest) httpObject).method().toString().equals("CONNECT")) {
                                         HttpHeaders.addHeader((HttpRequest)httpObject, HttpHeaders.Names.PROXY_AUTHORIZATION, "Basic " + chainedProxyAuth);
                                     }
                                 }


### PR DESCRIPTION
When chaining upstream proxy to BMP through HTTPS connection, the upstream proxy credentials should be sent only with CONNECT request. Otherwise, if the upstream proxy does not provide man-in-the-midle, it will be unable to dismiss Proxy-Authorization header, so the header will eventually leak to the end point site, which provides serious security flaw. 
I used this site to see this header: https://www.piliapp.com/what-is-my/http-request-headers/
Other test sites might drop it silently.

To fix this, I have added 2 more conditions on adding the credentials header:
1. The request should be CONNECT 
2. Otherwise the uri should not start with '/', which means we are in plain HTTP mode. 
In HTTP mode we should always pass credentials with each request.

I did not test this extensively, but hope this will help.

Best Regards!