### PR TITLE
[brotli] Add brotli support backed by org.brotli.dec

### DIFF
--- a/browsermob-core/pom.xml
+++ b/browsermob-core/pom.xml
@@ -139,6 +139,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- use google brotli for brotli decoding-->
+        <dependency>
+            <groupId>org.brotli</groupId>
+            <artifactId>dec</artifactId>
+            <version>0.1.2</version>
+        </dependency>
+
         <!-- Netty will use javassist to improve performance if it is present on the classpath, but it is not required -->
         <dependency>
             <groupId>org.javassist</groupId>

--- a/browsermob-core/src/main/java/net/lightbody/bmp/filters/ServerResponseCaptureFilter.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/filters/ServerResponseCaptureFilter.java
@@ -25,6 +25,7 @@ import java.io.IOException;
  */
 public class ServerResponseCaptureFilter extends HttpFiltersAdapter {
     private static final Logger log = LoggerFactory.getLogger(ServerResponseCaptureFilter.class);
+    private static final String BROTLI_COMPRESSION = "br";
 
     /**
      * Populated by serverToProxyResponse() when processing the HttpResponse object
@@ -129,6 +130,13 @@ public class ServerResponseCaptureFilter extends HttpFiltersAdapter {
         if (contentEncoding.equals(HttpHeaders.Values.GZIP)) {
             try {
                 fullResponseContents = BrowserMobHttpUtil.decompressContents(getRawResponseContents());
+                decompressionSuccessful = true;
+            } catch (RuntimeException e) {
+                log.warn("Failed to decompress response with encoding type " + contentEncoding + " when decoding request from " + originalRequest.getUri(), e);
+            }
+        } else if(contentEncoding.equals(BROTLI_COMPRESSION)) {
+            try {
+                fullResponseContents = BrowserMobHttpUtil.decompressBrotliContents(getRawResponseContents());
                 decompressionSuccessful = true;
             } catch (RuntimeException e) {
                 log.warn("Failed to decompress response with encoding type " + contentEncoding + " when decoding request from " + originalRequest.getUri(), e);

--- a/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/util/BrowserMobHttpUtil.java
@@ -3,6 +3,7 @@ package net.lightbody.bmp.util;
 import com.google.common.io.BaseEncoding;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.MediaType;
+import org.brotli.dec.BrotliInputStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -78,7 +80,7 @@ public class BrowserMobHttpUtil {
     /**
      * Decompresses the gzipped byte stream.
      *
-     * @param fullMessage gzipped byte stream to decomress
+     * @param fullMessage gzipped byte stream to decompress
      * @return decompressed bytes
      * @throws DecompressionException thrown if the fullMessage cannot be read or decompressed for any reason
      */
@@ -106,6 +108,42 @@ public class BrowserMobHttpUtil {
                 }
             } catch (IOException e) {
                 log.warn("Unable to close gzip stream", e);
+            }
+        }
+        return fullMessage;
+    }
+
+    /**
+     * Decompresses the brotli byze stream
+     *
+     * @param fullMessage brotli byte stream to decompress
+     * @return decompressed bytes
+    * @throws DecompressionException thrown if the fullMessage cannot be read or decompressed for any reason
+     */
+    public static byte[] decompressBrotliContents(byte[] fullMessage) throws DecompressionException {
+        InputStream brotliReader = null;
+        ByteArrayOutputStream uncompressed;
+        try {
+            brotliReader = new BrotliInputStream(new ByteArrayInputStream(fullMessage));
+
+            uncompressed = new ByteArrayOutputStream(fullMessage.length);
+
+            byte[] decompressBuffer = new byte[DECOMPRESS_BUFFER_SIZE];
+            int bytesRead;
+            while ((bytesRead = brotliReader.read(decompressBuffer)) > -1) {
+                uncompressed.write(decompressBuffer, 0, bytesRead);
+            }
+
+            fullMessage = uncompressed.toByteArray();
+        } catch (IOException e) {
+            throw new DecompressionException("Unable to decompress response", e);
+        } finally {
+            try {
+                if (brotliReader != null) {
+                    brotliReader.close();
+                }
+            } catch (IOException e) {
+                log.warn("Unable to close brotli stream", e);
             }
         }
         return fullMessage;


### PR DESCRIPTION
Hello dear browsermob maintainers.
I think brotli support is a very pressing feature if you want to use browsermob anywhere near 2018. However I noticed that the current #742 PR is oddly broken. This PR is cleaner as it minimally intrudes setup with org.brotli.dec (no binaries, no platform dependant code).
Please send feedback along and merge this as soon as possible.
