### PR TITLE
Update HarPage.java

### DIFF
--- a/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarPage.java
+++ b/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarPage.java
@@ -55,6 +55,10 @@ public class HarPage {
         return pageTimings;
     }
 
+    public void setPageTimings(HarPageTimings pageTimings) {
+        this.pageTimings = pageTimings;
+    }
+    
     public String getComment() {
         return comment;
     }


### PR DESCRIPTION
Previous branches included a setPageTimings method, but it looks like this was omitted in more recent revisions. In order to get the onContentLoad to store properly for a given Har page, I believe this will be needed again.

In a previous fork, PerformanceTiming,java was used to inject the browser timings into the Har page. setPageTimings(pageTimings) appears to be the only method that is no longer defined.