### PR TITLE
Forward SIGTERM and SIGINT down to java process in wrapper script

### DIFF
--- a/browsermob-dist/src/main/scripts/browsermob-proxy
+++ b/browsermob-dist/src/main/scripts/browsermob-proxy
@@ -9,11 +9,16 @@ then
     JAVACMD="java"
 fi
 
+trap 'kill -TERM $PID' TERM INT
 "$JAVACMD" $JAVA_OPTS \
            -Dapp.name="browsermob-proxy" \
            -Dbasedir="$BASEDIR" \
            -jar "$BASEDIR/lib/browsermob-dist-${project.version}.jar" \
-           "$@"
+           "$@" &
+PID=$!
+wait $PID
+trap - TERM INT
+wait $PID
 
 # if we couldn't find java, print a helpful error message
 if [ $? -eq 127 ]

--- a/browsermob-dist/src/main/scripts/browsermob-proxy
+++ b/browsermob-dist/src/main/scripts/browsermob-proxy
@@ -9,6 +9,8 @@ then
     JAVACMD="java"
 fi
 
+# start process in the background and handle SIGTERM/SIGINT
+# see https://veithen.io/2014/11/16/sigterm-propagation.html
 trap 'kill -TERM $PID' TERM INT
 "$JAVACMD" $JAVA_OPTS \
            -Dapp.name="browsermob-proxy" \


### PR DESCRIPTION
This patch adds trap handlers to the sh wrapper script, so that the Java process terminates when the sh process receives either SIGTERM or SIGINT.

I observed that the Java process kept running when the wrapper process gets killed by Ctrl-C or a signal sent over another way.
The trap handler makes sure that it forwards the signal to the Java child process, which does not happen otherwise in sh compatible shells.

The only drawback I see is that SIGKILL is not handled as it is not possible to intercept it.
As the python lib (https://github.com/AutomatedTester/browsermob-proxy-py) is using SIGKILL this unfortunately does not solve the problem there (https://github.com/AutomatedTester/browsermob-proxy-py/issues/76).


An even simpler solution would be to just run the Java process with exec. 
However in that case the JAVACMD check would have to happen before and it would need to be made without invoking the browsermod-proxy code.
So I decided that this would change less in the script.
I am happy to provide an alternative version if that is desireable.