### PR TITLE
Pplt 9999 allow upstreamproxy in legacy

### DIFF
--- a/browsermob-legacy/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
+++ b/browsermob-legacy/src/main/java/net/lightbody/bmp/proxy/http/BrowserMobHttpClient.java
@@ -528,6 +528,7 @@ public class BrowserMobHttpClient {
 
     private URI makeUri(String url) throws URISyntaxException {
         // MOB-120: check for | character and change to correctly escaped %7C
+        /*
         url = url.replace(" ", "%20");
         url = url.replace(">", "%3C");
         url = url.replace("<", "%3E");
@@ -542,8 +543,9 @@ public class BrowserMobHttpClient {
         url = url.replace("]", "%5D");
         url = url.replace("`", "%60");
         url = url.replace("\"", "%22");
-
+        */
         URI uri = new URI(url);
+        // System.out.println(url);
 
         // are we using the default ports for http/https? if so, let's rewrite the URI to make sure the :80 or :443
         // is NOT included in the string form the URI. The reason we do this is that in HttpClient 4.0 the Host header

--- a/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
+++ b/browsermob-rest/src/main/java/net/lightbody/bmp/proxy/bricks/ProxyResource.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -598,6 +599,20 @@ public class ProxyResource {
         String quietPeriodInMs = request.param("quietPeriodInMs");
         String timeoutInMs = request.param("timeoutInMs");
         proxy.waitForNetworkTrafficToStop(Integer.parseInt(quietPeriodInMs), Integer.parseInt(timeoutInMs));
+        return Reply.saying().ok();
+    }
+
+    @Put
+    @At("/:port/upstreamProxy/:upstreamHost/:upstreamPort")
+    public Reply<?> upstreamProxy(@Named("port") int port,
+                                  @Named("upstreamHost") String upstreamHost,
+                                  @Named("upstreamPort") int upstreamPort,
+                                  Request<String> request) {
+        BrowserMobProxy proxy = (BrowserMobProxy) proxyManager.get(port);
+        if (proxy == null) {
+            return Reply.saying().notFound();
+        }
+        proxy.setChainedProxy(new InetSocketAddress(upstreamHost, upstreamPort));
         return Reply.saying().ok();
     }
 


### PR DESCRIPTION
- Added an endpoint to allow setting upstream proxy post proxy is created in legacy mode ( we did this because of existing bug that breaks creation of proxy with upstream in legacy mode)
- Removed encoding of special chars cause it was breaking mapping logic on jackproxy side